### PR TITLE
Add PostgreSQL 17 and 18 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,13 +52,13 @@ jobs:
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3.6.2
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -79,13 +79,13 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           # Cache the image layers
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         PGVERSION:
           - 16
+          - 17
+          - 18
         TEST:
           - ci
           - pagila
@@ -49,6 +51,10 @@ jobs:
       - name: Set environment variables
         run: |
             echo "TEST=${{ matrix.TEST }}" >> $GITHUB_ENV
+            echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+
+      - name: Build pgcopydb Docker image
+        run: make build
 
       - name: Create docker volumes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### pgcopydb (Unreleased) ###
+
+### Added
+* Add support for PostgreSQL 17 and 18
+* Update all test infrastructure to PostgreSQL 17
+* Update CI pipeline to test against PostgreSQL 16, 17, and 18
+
 ### pgcopydb v0.17 (August 7, 2024) ###
 
 pgcopydb v0.17 is mostly a bugfix release. New features include

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     libkrb5-dev \
     liblz4-dev \
     libncurses6 \
+    libnuma-dev \
     libpam-dev \
     libpq-dev \
     libpq5 \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 TOP := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 PGCOPYDB ?= $(TOP)src/bin/pgcopydb/pgcopydb
+PGVERSION ?= 16
 
 all: bin ;
 
@@ -53,7 +54,7 @@ indent:
 	citus_indent
 
 build: version
-	docker build -t pgcopydb .
+	docker build --build-arg PGVERSION=$(PGVERSION) -t pgcopydb .
 
 echo-version: GIT-VERSION-FILE
 	@awk '{print $$3}' $<

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -48,7 +48,7 @@ of pgcopydb used, and can do that in the JSON format when using the
    $ pgcopydb version
    pgcopydb version 0.13.1.g868ad77
    compiled with PostgreSQL 13.11 (Debian 13.11-0+deb11u1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
-   compatible with Postgres 10, 11, 12, 13, 14, and 15
+   compatible with Postgres 10, 11, 12, 13, 14, 15, 16, 17, and 18
 
 In JSON:
 

--- a/src/bin/lib/pg/snprintf.c
+++ b/src/bin/lib/pg/snprintf.c
@@ -37,6 +37,17 @@
 #include <math.h>
 
 /*
+ * Fallback definitions for PostgreSQL 18+ which removed HAVE_LONG_INT_64
+ * and HAVE_LONG_LONG_INT_64 macros. On all modern platforms, long long
+ * is guaranteed to be at least 64 bits per C99.
+ */
+#if SIZEOF_SIZE_T == 8
+#if !defined(HAVE_LONG_INT_64) && !defined(HAVE_LONG_LONG_INT_64)
+#define HAVE_LONG_LONG_INT_64 1
+#endif
+#endif
+
+/*
  * We used to use the platform's NL_ARGMAX here, but that's a bad idea,
  * first because the point of this module is to remove platform dependencies
  * not perpetuate them, and second because some platforms use ridiculously

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -124,7 +124,7 @@ cli_print_version(int argc, char **argv)
 	{
 		fformat(stdout, "pgcopydb version %s\n", VERSION_STRING);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 11, 12, 13, 14, 15, and 16\n");
+		fformat(stdout, "compatible with Postgres 11, 12, 13, 14, 15, 16, 17, and 18\n");
 	}
 
 	exit(0);

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -748,6 +748,13 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			continue;
 		}
 
+		/* skip \restrict and \unrestrict metacommands (PostgreSQL 17.6+) */
+		if (strncmp(currentLine, "\\restrict", 9) == 0 ||
+			strncmp(currentLine, "\\unrestrict", 11) == 0)
+		{
+			continue;
+		}
+
 		char *createRole = "CREATE ROLE ";
 		int createRoleLen = strlen(createRole);
 

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -1,6 +1,10 @@
 ARG PGVERSION=16
+ARG PGCOPYDB_IMAGE=pgcopydb:latest
 
-FROM debian:bullseye-slim
+# Create a named stage from the pgcopydb image for COPY --from
+FROM $PGCOPYDB_IMAGE as pgcopydb_source
+
+FROM debian:bookworm-slim
 
 ARG PGVERSION
 
@@ -27,7 +31,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
 
 # bypass initdb of a "main" cluster
 RUN echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
@@ -44,8 +48,8 @@ RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
 RUN useradd -rm -d /var/lib/postgres -s /bin/bash -g postgres -G sudo docker
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-COPY --from=pgcopydb /usr/local/bin/sqlite3 /usr/local/bin
-COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin
+COPY --from=pgcopydb_source /usr/local/bin/sqlite3 /usr/local/bin
+COPY --from=pgcopydb_source /usr/local/bin/pgcopydb /usr/local/bin
 
 COPY .psqlrc /var/lib/postgres
 COPY .sqliterc /var/lib/postgres

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,13 @@
 # Copyright (c) 2021 The PostgreSQL Global Development Group.
 # Licensed under the PostgreSQL License.
 
-PGVERSION ?= 16
+PGVERSION ?= 17
+export PGVERSION
+
+# Auto-detect docker or podman
+DOCKER ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
+export DOCKER
+
 BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
 all: pagila pagila-multi-steps blobs unit filtering extensions \
@@ -58,7 +64,8 @@ timescaledb: build
 	$(MAKE) -C $@
 
 build:
-	docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
+	cd .. && $(DOCKER) build $(BUILD_ARGS) -t pgcopydb:pg$(PGVERSION) -f Dockerfile .
+	$(DOCKER) build $(BUILD_ARGS) --build-arg PGCOPYDB_IMAGE=pgcopydb:pg$(PGVERSION) -t pagila -f Dockerfile.pagila .
 
 .PHONY: all build
 .PHONY: pagila pagila-multi-steps blobs unit filtering extensions

--- a/tests/blobs/Makefile
+++ b/tests/blobs/Makefile
@@ -4,13 +4,13 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 import:
 	psql --single-transaction --no-psqlrc -f import.sql

--- a/tests/blobs/compose.yaml
+++ b/tests/blobs/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/blobs/copydb.sh
+++ b/tests/blobs/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/cdc-endpos-between-transaction/Dockerfile.pg
+++ b/tests/cdc-endpos-between-transaction/Dockerfile.pg
@@ -1,5 +1,7 @@
-FROM postgres:13-bullseye
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-endpos-between-transaction/Makefile
+++ b/tests/cdc-endpos-between-transaction/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/cdc-endpos-between-transaction/compose.yaml
+++ b/tests/cdc-endpos-between-transaction/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/cdc-low-level/Makefile
+++ b/tests/cdc-low-level/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/cdc-low-level/compose.yaml
+++ b/tests/cdc-low-level/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-low-level/copydb.sh
+++ b/tests/cdc-low-level/copydb.sh
@@ -2,6 +2,9 @@
 
 set -x
 set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
 set -o pipefail
 
 # This script expects the following environment variables to be set:

--- a/tests/cdc-test-decoding/Makefile
+++ b/tests/cdc-test-decoding/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/cdc-test-decoding/compose.yaml
+++ b/tests/cdc-test-decoding/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/cdc-wal2json/Dockerfile.pg
+++ b/tests/cdc-wal2json/Dockerfile.pg
@@ -1,5 +1,7 @@
-FROM postgres:13-bullseye
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-wal2json/Makefile
+++ b/tests/cdc-wal2json/Makefile
@@ -6,15 +6,15 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	$(DOCKER) compose up $(COMPOSE_EXIT)
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/cdc-wal2json/compose.yaml
+++ b/tests/cdc-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-wal2json/copydb.sh
+++ b/tests/cdc-wal2json/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/endpos-in-multi-wal-txn/Dockerfile.pg
+++ b/tests/endpos-in-multi-wal-txn/Dockerfile.pg
@@ -1,5 +1,7 @@
-FROM postgres:13-bullseye
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/endpos-in-multi-wal-txn/Makefile
+++ b/tests/endpos-in-multi-wal-txn/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/endpos-in-multi-wal-txn/compose.yaml
+++ b/tests/endpos-in-multi-wal-txn/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/endpos-in-multi-wal-txn/copydb.sh
+++ b/tests/endpos-in-multi-wal-txn/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/extensions/Dockerfile.pg
+++ b/tests/extensions/Dockerfile.pg
@@ -1,9 +1,10 @@
-FROM postgres:13-bullseye
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-      postgresql-13-wal2json \
-      postgresql-13-partman \
-      postgresql-13-postgis-3 \
+      postgresql-${PGVERSION}-wal2json \
+      postgresql-${PGVERSION}-postgis-3 \
       postgis \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/extensions/Makefile
+++ b/tests/extensions/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/extensions/compose.yaml
+++ b/tests/extensions/compose.yaml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.pg
+      args:
+        - PGVERSION=${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -18,6 +20,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.pg
+      args:
+        - PGVERSION=${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/filtering/Makefile
+++ b/tests/filtering/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/filtering/compose.yaml
+++ b/tests/filtering/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/follow-9.6/Makefile
+++ b/tests/follow-9.6/Makefile
@@ -9,16 +9,16 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	$(DOCKER) compose up $(COMPOSE_EXIT)
 
 run: build fix-volumes
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down --volumes --remove-orphans
+	$(DOCKER) compose down --volumes --remove-orphans
 
 build:
-	docker compose build
+	$(DOCKER) compose build
 
 VPATH   = /var/run/pgcopydb
 CNAME   = follow-9.6

--- a/tests/follow-9.6/compose.yaml
+++ b/tests/follow-9.6/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.pg
       args:
-        - PGVERSION
+        - PGVERSION=9.6
     expose:
       - 5432
     env_file:
@@ -18,7 +18,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     env_file:
@@ -34,7 +34,7 @@ services:
       context: .
       dockerfile: Dockerfile.inject
     environment:
-      PGVERSION:
+      PGVERSION: "9.6"
     env_file:
       - ../uris.env
       - ../paths.env
@@ -46,7 +46,7 @@ services:
     image: follow-9.6
     build: .
     environment:
-      PGVERSION:
+      PGVERSION: "9.6"
       PGCOPYDB_TABLE_JOBS: 4
       PGCOPYDB_INDEX_JOBS: 2
       PGCOPYDB_SPLIT_TABLES_LARGER_THAN: 200kB

--- a/tests/follow-9.6/copydb.sh
+++ b/tests/follow-9.6/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/follow-data-only/Dockerfile.pg
+++ b/tests/follow-data-only/Dockerfile.pg
@@ -1,5 +1,7 @@
-FROM postgres:13-bullseye
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-data-only/Makefile
+++ b/tests/follow-data-only/Makefile
@@ -6,16 +6,16 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	$(DOCKER) compose up $(COMPOSE_EXIT)
 
 run: build fix-volumes
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down --volumes --remove-orphans
+	$(DOCKER) compose down --volumes --remove-orphans
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 VPATH   = /var/run/pgcopydb
 CNAME   = follow-data-only

--- a/tests/follow-data-only/compose.yaml
+++ b/tests/follow-data-only/compose.yaml
@@ -14,7 +14,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:15-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     env_file:

--- a/tests/follow-data-only/copydb.sh
+++ b/tests/follow-data-only/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/follow-wal2json/Dockerfile.pg
+++ b/tests/follow-wal2json/Dockerfile.pg
@@ -1,5 +1,7 @@
-FROM postgres:13-bullseye
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-wal2json/Makefile
+++ b/tests/follow-wal2json/Makefile
@@ -6,16 +6,16 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	$(DOCKER) compose up $(COMPOSE_EXIT)
 
 run: build fix-volumes
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 VPATH   = /var/run/pgcopydb
 CNAME   = follow-wal2json

--- a/tests/follow-wal2json/compose.yaml
+++ b/tests/follow-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:16-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     env_file:

--- a/tests/follow-wal2json/copydb.sh
+++ b/tests/follow-wal2json/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/pagila-multi-steps/Makefile
+++ b/tests/pagila-multi-steps/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/pagila-multi-steps/compose.yaml
+++ b/tests/pagila-multi-steps/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/pagila-standby/Makefile
+++ b/tests/pagila-standby/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: down build test

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -9,7 +9,7 @@ x-postgres-base-env-allow-replication: &x-postgres-base-env-allow-replication
   POSTGRES_HOST_AUTH_METHOD: "trust\nhost replication all 0.0.0.0/0 trust"
 
 x-postgres-base: &x-postgres-base
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     user: postgres
     expose:
       - 5432
@@ -42,18 +42,25 @@ services:
     environment:
         <<: *x-postgres-base-env
     command: |
-     bash -c "
-      until pg_basebackup --pgdata=/var/lib/postgresql/data -R --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila
+     bash -c '
+      until pg_basebackup --pgdata="$$PGDATA" -R --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila
       do
-      echo 'Waiting for primary to connect...'
+      echo "Waiting for primary to connect..."
       sleep 1s
       done
-      echo 'Backup done, starting replica...'
-      chmod 0700 /var/lib/postgresql/data
+      echo "Backup done, starting replica..."
+      chmod 0700 "$$PGDATA"
       postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-     "
+     '
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     depends_on:
-      - source
+      source:
+        condition: service_healthy
 
   target:
     <<: *x-postgres-base
@@ -82,6 +89,9 @@ services:
       PGCOPYDB_SPLIT_TABLES_LARGER_THAN: 200kB
       PGCOPYDB_FAIL_FAST: "true"
     depends_on:
-      - source
-      - source-standby
-      - target
+      source:
+        condition: service_healthy
+      source-standby:
+        condition: service_healthy
+      target:
+        condition: service_healthy

--- a/tests/pagila-standby/copydb.sh
+++ b/tests/pagila-standby/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/pagila/Makefile
+++ b/tests/pagila/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: down build test

--- a/tests/pagila/compose.yaml
+++ b/tests/pagila/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/timescaledb/Makefile
+++ b/tests/timescaledb/Makefile
@@ -6,15 +6,15 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	$(DOCKER) compose up $(COMPOSE_EXIT)
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/timescaledb/compose.yml
+++ b/tests/timescaledb/compose.yml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: timescale/timescaledb:latest-pg13
+    image: timescale/timescaledb:latest-pg${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: timescale/timescaledb:latest-pg13
+    image: timescale/timescaledb:latest-pg${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/timescaledb/copydb.sh
+++ b/tests/timescaledb/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	$(DOCKER) compose run test
 
 down:
-	docker compose down
+	$(DOCKER) compose down
 
 build:
-	docker compose build --quiet
+	$(DOCKER) compose build
 
 .PHONY: run down build test

--- a/tests/unit/compose.yaml
+++ b/tests/unit/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:13-bullseye
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
 # This script expects the following environment variables to be set:
 #
 #  - PGCOPYDB_SOURCE_PGURI

--- a/tests/unit/expected/3-collations.out
+++ b/tests/unit/expected/3-collations.out
@@ -1,7 +1,6 @@
-       OID |                 Name |          Object name
------------+----------------------+---------------------
-     12329 |           en_US.utf8 | database postgres
-     12440 |          de-DE-x-icu | column f2 of table colls 
-     12559 |          en-US-x-icu | column f2 of table mycoltab 
-     12658 |          fr-FR-x-icu | column f1 of table colls 
-     16418 |                mycol | column f1 of table mycoltab
+       OID |                 Name | Object name
+ | en_US.utf8 | database postgres
+ | de-DE-x-icu | column f2 of table colls
+ | en-US-x-icu | column f2 of table mycoltab
+ | fr-FR-x-icu | column f1 of table colls
+ | mycol | column f1 of table mycoltab

--- a/tests/unit/script/3-collations.sh
+++ b/tests/unit/script/3-collations.sh
@@ -7,4 +7,5 @@ set -e
 #
 #  - PGCOPYDB_SOURCE_PGURI
 
-pgcopydb list collations -q --dir /tmp/collations 2>&1
+# Filter out OID column since OIDs vary between runs
+pgcopydb list collations -q --dir /tmp/collations 2>&1 | awk '{ if (NR <= 2) print; else if (NF >= 3) { $1 = ""; print } }'


### PR DESCRIPTION
## Summary
- Add compatibility checks and build support for PostgreSQL 17 and 18
- Update Docker build infrastructure for multi-version support
- Update all test configurations for PostgreSQL version flexibility
- Fix extensions, follow-9.6, and pagila-standby tests for new PG versions

Rebased from teknogeek0/pgcopydb PR #3.