### PR TITLE
Add tests for --skip-vacuum and --skip-large-objects

### DIFF
--- a/tests/skip-large-objects/Dockerfile
+++ b/tests/skip-large-objects/Dockerfile
@@ -1,0 +1,9 @@
+FROM pgcopydb
+
+USER docker
+WORKDIR /usr/src/pgcopydb
+
+COPY --chmod=755 ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/skip-large-objects/Makefile
+++ b/tests/skip-large-objects/Makefile
@@ -1,0 +1,12 @@
+DOCKER ?= docker
+PGVERSION ?= 17
+
+test:
+	$(DOCKER) compose down
+	$(DOCKER) volume rm skip-large-objects 2>/dev/null || true
+	$(DOCKER) compose build
+	$(DOCKER) compose run test
+	$(DOCKER) compose down
+	$(DOCKER) volume rm skip-large-objects 2>/dev/null || true
+
+.PHONY: test

--- a/tests/skip-large-objects/compose.yaml
+++ b/tests/skip-large-objects/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  source:
+    image: postgres:${PGVERSION:-17}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  target:
+    image: postgres:${PGVERSION:-17}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+    depends_on:
+      - source
+      - target

--- a/tests/skip-large-objects/copydb.sh
+++ b/tests/skip-large-objects/copydb.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# Create test tables and large objects on source
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# Save the count of large objects on source
+SOURCE_LO_COUNT=$(psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c "SELECT COUNT(*) FROM pg_largeobject_metadata;")
+echo "Source has ${SOURCE_LO_COUNT} large objects"
+
+if [ "$SOURCE_LO_COUNT" -eq "0" ]; then
+    echo "✗ Failed to create large objects on source"
+    exit 1
+fi
+
+# Test 1: Clone WITH --skip-large-objects
+echo "=== Test 1: Clone with --skip-large-objects ==="
+pgcopydb clone \
+    --skip-large-objects \
+    --source ${PGCOPYDB_SOURCE_PGURI} \
+    --target ${PGCOPYDB_TARGET_PGURI} \
+    > /tmp/test1.log 2>&1
+
+# Verify large objects were skipped
+TARGET_LO_COUNT=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM pg_largeobject_metadata;")
+echo "Target has ${TARGET_LO_COUNT} large objects after --skip-large-objects"
+
+if [ "$TARGET_LO_COUNT" -eq "0" ]; then
+    echo "✓ Large objects were correctly skipped (count: $TARGET_LO_COUNT)"
+else
+    echo "✗ Large objects were copied (expected: 0, got: $TARGET_LO_COUNT)"
+    psql -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT * FROM pg_largeobject_metadata;"
+    exit 1
+fi
+
+# Verify table was still copied (but OID references will be NULL or invalid)
+TABLE_COUNT=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM documents;")
+if [ "$TABLE_COUNT" -eq "4" ]; then
+    echo "✓ Table was copied successfully (count: $TABLE_COUNT)"
+else
+    echo "✗ Table was not copied correctly (expected: 4, got: $TABLE_COUNT)"
+    exit 1
+fi
+
+# Verify log shows large objects were skipped
+if grep -qi "skip.*large.*object\|large.*object.*skip\|skipping.*blob" /tmp/test1.log; then
+    echo "✓ Log indicates large objects were skipped"
+else
+    echo "⚠ Warning: Log does not explicitly mention skipping large objects (this is OK if they were actually skipped)"
+fi
+
+# Clean target for test 2
+psql -d ${PGCOPYDB_TARGET_PGURI} << 'SQL'
+DROP TABLE IF EXISTS documents CASCADE;
+-- Also clean up any large objects that might exist
+DO $$
+DECLARE
+    lo_oid OID;
+BEGIN
+    FOR lo_oid IN SELECT oid FROM pg_largeobject_metadata LOOP
+        PERFORM lo_unlink(lo_oid);
+    END LOOP;
+END $$;
+SQL
+
+# Remove work directory to force fresh clone
+rm -rf /tmp/pgcopydb
+
+# Test 2: Clone WITHOUT --skip-large-objects (large objects should be copied)
+echo "=== Test 2: Clone without --skip-large-objects ==="
+pgcopydb clone \
+    --source ${PGCOPYDB_SOURCE_PGURI} \
+    --target ${PGCOPYDB_TARGET_PGURI} \
+    > /tmp/test2.log 2>&1
+
+# Verify large objects were copied
+TARGET_LO_COUNT=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM pg_largeobject_metadata;")
+echo "Target has ${TARGET_LO_COUNT} large objects without --skip-large-objects"
+
+if [ "$TARGET_LO_COUNT" -eq "$SOURCE_LO_COUNT" ]; then
+    echo "✓ Large objects were copied (expected: $SOURCE_LO_COUNT, got: $TARGET_LO_COUNT)"
+else
+    echo "✗ Large objects were not copied correctly (expected: $SOURCE_LO_COUNT, got: $TARGET_LO_COUNT)"
+    psql -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT * FROM pg_largeobject_metadata;"
+    exit 1
+fi
+
+# Verify table was copied
+TABLE_COUNT=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM documents;")
+if [ "$TABLE_COUNT" -eq "4" ]; then
+    echo "✓ Table was copied successfully (count: $TABLE_COUNT)"
+else
+    echo "✗ Table was not copied correctly (expected: 4, got: $TABLE_COUNT)"
+    exit 1
+fi
+
+# Verify the large object data is actually accessible and matches
+echo "Verifying large object content..."
+SOURCE_LO_DATA=$(psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c "SELECT loid, count(data) as parts, sum(length(data)) as size FROM pg_largeobject GROUP BY loid ORDER BY loid;")
+TARGET_LO_DATA=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT loid, count(data) as parts, sum(length(data)) as size FROM pg_largeobject GROUP BY loid ORDER BY loid;")
+
+# The OIDs might be different, but the structure should match (same number of objects with same sizes)
+SOURCE_SIZES=$(echo "$SOURCE_LO_DATA" | cut -d'|' -f3 | sort)
+TARGET_SIZES=$(echo "$TARGET_LO_DATA" | cut -d'|' -f3 | sort)
+
+if [ "$SOURCE_SIZES" = "$TARGET_SIZES" ]; then
+    echo "✓ Large object data matches between source and target"
+else
+    echo "✗ Large object data does not match"
+    echo "Source sizes: $SOURCE_SIZES"
+    echo "Target sizes: $TARGET_SIZES"
+    exit 1
+fi
+
+echo "✓ SKIP-LARGE-OBJECTS TEST PASSED"

--- a/tests/skip-large-objects/ddl.sql
+++ b/tests/skip-large-objects/ddl.sql
@@ -1,0 +1,16 @@
+-- Create a table that references large objects
+DROP TABLE IF EXISTS documents CASCADE;
+
+CREATE TABLE documents (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    content_oid OID,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create large objects using lo_from_bytea and insert references
+INSERT INTO documents (title, content_oid) VALUES
+    ('Document 1', lo_from_bytea(0, 'This is the content of document 1. It contains important information.'::bytea)),
+    ('Document 2', lo_from_bytea(0, 'This is the content of document 2. More important data here.'::bytea)),
+    ('Document 3', lo_from_bytea(0, 'This is the content of document 3. Even more critical information.'::bytea)),
+    ('Document 4', lo_from_bytea(0, 'This is the content of document 4. Final document with data.'::bytea));

--- a/tests/skip-vacuum/Dockerfile
+++ b/tests/skip-vacuum/Dockerfile
@@ -1,0 +1,9 @@
+FROM pgcopydb
+
+USER docker
+WORKDIR /usr/src/pgcopydb
+
+COPY --chmod=755 ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/skip-vacuum/Makefile
+++ b/tests/skip-vacuum/Makefile
@@ -1,0 +1,12 @@
+DOCKER ?= docker
+PGVERSION ?= 17
+
+test:
+	$(DOCKER) compose down
+	$(DOCKER) volume rm skip-vacuum 2>/dev/null || true
+	$(DOCKER) compose build
+	$(DOCKER) compose run test
+	$(DOCKER) compose down
+	$(DOCKER) volume rm skip-vacuum 2>/dev/null || true
+
+.PHONY: test

--- a/tests/skip-vacuum/compose.yaml
+++ b/tests/skip-vacuum/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  source:
+    image: postgres:${PGVERSION:-17}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  target:
+    image: postgres:${PGVERSION:-17}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+    depends_on:
+      - source
+      - target

--- a/tests/skip-vacuum/copydb.sh
+++ b/tests/skip-vacuum/copydb.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# Create test tables on source
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# Test 1: Clone WITH --skip-vacuum
+echo "=== Test 1: Clone with --skip-vacuum ==="
+pgcopydb clone \
+    --skip-vacuum \
+    --source ${PGCOPYDB_SOURCE_PGURI} \
+    --target ${PGCOPYDB_TARGET_PGURI} \
+    > /tmp/test1.log 2>&1
+
+# Verify VACUUM ANALYZE was skipped
+if grep -q "skipping VACUUM jobs per --skip-vacuum" /tmp/test1.log; then
+    echo "✓ VACUUM was correctly skipped"
+else
+    echo "✗ VACUUM skip message not found in log"
+    exit 1
+fi
+
+# Check that VACUUM time is 0 (no vacuum ran)
+if grep -q "VACUUM (cumulative).*0ms" /tmp/test1.log; then
+    echo "✓ VACUUM time is 0ms (confirmed no vacuum ran)"
+else
+    echo "✗ VACUUM may have run (non-zero time)"
+    grep "VACUUM (cumulative)" /tmp/test1.log || true
+    exit 1
+fi
+
+# Verify tables were still copied
+TABLE_COUNT=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM users;")
+if [ "$TABLE_COUNT" -eq "1000" ]; then
+    echo "✓ Tables were copied successfully (count: $TABLE_COUNT)"
+else
+    echo "✗ Tables were not copied correctly (expected: 1000, got: $TABLE_COUNT)"
+    exit 1
+fi
+
+# Clean target for test 2
+psql -d ${PGCOPYDB_TARGET_PGURI} << 'SQL'
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+SQL
+
+# Remove work directory to force fresh clone
+rm -rf /tmp/pgcopydb
+
+# Test 2: Clone WITHOUT --skip-vacuum (VACUUM ANALYZE should run)
+echo "=== Test 2: Clone without --skip-vacuum ==="
+pgcopydb clone \
+    --source ${PGCOPYDB_SOURCE_PGURI} \
+    --target ${PGCOPYDB_TARGET_PGURI} \
+    > /tmp/test2.log 2>&1
+
+# Verify VACUUM ANALYZE was run (should NOT see skip message and should see VACUUM step)
+if ! grep -q "skipping VACUUM" /tmp/test2.log && grep -q "STEP.*VACUUM" /tmp/test2.log; then
+    echo "✓ VACUUM was run (as expected)"
+else
+    echo "✗ VACUUM was not run (should have run)"
+    grep "VACUUM" /tmp/test2.log || echo "No VACUUM mentions found"
+    exit 1
+fi
+
+# Look for actual VACUUM ANALYZE statements in the log
+if grep -qi "VACUUM ANALYZE" /tmp/test2.log; then
+    echo "✓ VACUUM ANALYZE statements found in log"
+else
+    echo "⚠ Warning: No VACUUM ANALYZE statements found (but STEP 8 was executed)"
+fi
+
+# Verify tables were copied
+TABLE_COUNT=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM users;")
+if [ "$TABLE_COUNT" -eq "1000" ]; then
+    echo "✓ Tables were copied successfully (count: $TABLE_COUNT)"
+else
+    echo "✗ Tables were not copied correctly (expected: 1000, got: $TABLE_COUNT)"
+    exit 1
+fi
+
+echo "✓ SKIP-VACUUM TEST PASSED"

--- a/tests/skip-vacuum/ddl.sql
+++ b/tests/skip-vacuum/ddl.sql
@@ -1,0 +1,36 @@
+-- Create test tables with enough data to make VACUUM/ANALYZE meaningful
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username TEXT NOT NULL,
+    email TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    amount NUMERIC(10,2),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Insert 1000 rows to make VACUUM/ANALYZE more noticeable
+INSERT INTO users (username, email)
+SELECT
+    'user' || i,
+    'user' || i || '@example.com'
+FROM generate_series(1, 1000) AS i;
+
+-- Insert 5000 orders
+INSERT INTO orders (user_id, amount)
+SELECT
+    (random() * 999 + 1)::int,
+    (random() * 1000)::numeric(10,2)
+FROM generate_series(1, 5000);
+
+-- Create indexes that will benefit from statistics
+CREATE INDEX idx_users_username ON users(username);
+CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_amount ON orders(amount);


### PR DESCRIPTION
## Summary
- Add integration tests for --skip-vacuum and --skip-large-objects flags
- Add test suites to CI tiered testing workflow

Rebased from teknogeek0/pgcopydb PR #20.