### PR TITLE
Add resilient retry with exponential backoff for COPY workers

### DIFF
--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -85,6 +85,16 @@
 #define POSTGRES_PING_RETRY_CAP_SLEEP_TIME (2 * 1000) /* milliseconds */
 #define POSTGRES_PING_RETRY_BASE_SLEEP_TIME 5         /* milliseconds */
 
+/* COPY worker connection retry: 5 min per reconnect attempt, 30s cap between pings */
+#define COPY_WORKER_PING_RETRY_TIMEOUT 300                /* seconds */
+#define COPY_WORKER_PING_RETRY_CAP_SLEEP_TIME (30 * 1000) /* milliseconds */
+#define COPY_WORKER_PING_RETRY_BASE_SLEEP_TIME 500        /* milliseconds */
+
+/* COPY worker outer retry: 30 min total budget, 5 min cap between COPY attempts */
+#define COPY_WORKER_RETRY_TIMEOUT (30 * 60)               /* seconds */
+#define COPY_WORKER_RETRY_CAP_SLEEP_TIME (5 * 60 * 1000)  /* milliseconds */
+#define COPY_WORKER_RETRY_BASE_SLEEP_TIME (2 * 1000)      /* milliseconds */
+
 #define POSTGRES_PORT 5432
 
 /* default replication slot and origin for logical replication */

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -235,6 +235,22 @@ pgsql_set_interactive_retry_policy(ConnectionRetryPolicy *retryPolicy)
 }
 
 
+/*
+ * pgsql_set_copy_retry_policy sets the retry policy for COPY worker
+ * connections: 5-minute timeout, 30s sleep cap, 500ms base. This gives
+ * COPY workers a much longer window to reconnect after source outages.
+ */
+void
+pgsql_set_copy_retry_policy(ConnectionRetryPolicy *retryPolicy)
+{
+	(void) pgsql_set_retry_policy(retryPolicy,
+								  COPY_WORKER_PING_RETRY_TIMEOUT,
+								  -1, /* unbounded number of attempts */
+								  COPY_WORKER_PING_RETRY_CAP_SLEEP_TIME,
+								  COPY_WORKER_PING_RETRY_BASE_SLEEP_TIME);
+}
+
+
 #define min(a, b) (a < b ? a : b)
 
 /*

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -252,6 +252,7 @@ void pgsql_set_retry_policy(ConnectionRetryPolicy *retryPolicy,
 							int maxSleepTime,
 							int baseSleepTime);
 void pgsql_set_interactive_retry_policy(ConnectionRetryPolicy *retryPolicy);
+void pgsql_set_copy_retry_policy(ConnectionRetryPolicy *retryPolicy);
 int pgsql_compute_connection_retry_sleep_time(ConnectionRetryPolicy *retryPolicy);
 bool pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy);
 


### PR DESCRIPTION
## Summary
- Add retry logic with exponential backoff for COPY worker failures
- Workers retry up to 10 times with delays from 1s to 30 minutes
- Handles transient connection errors during long-running COPY operations

Rebased from teknogeek0/pgcopydb PR #40.