### PR TITLE
Fix schema catalog population and --follow with --filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Update all test infrastructure to PostgreSQL 17
 * Update CI pipeline to test against PostgreSQL 16, 17, and 18
 
+### Fixed
+* Fix "database source is already in use" error when using `--follow` with `--filters` (#829, #871, #910)
+* Fix catalog mismatch errors when using different commands in sequence with filters (#869, #868)
+* Fix transaction state management for `clone --follow --snapshot` workflows
+* Make catalog_attach() idempotent to prevent concurrent process conflicts
+
 ### pgcopydb v0.17 (August 7, 2024) ###
 
 pgcopydb v0.17 is mostly a bugfix release. New features include

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -319,6 +319,7 @@ bool catalog_open_from_specs(CopyDataSpec *copySpecs);
 bool catalog_close_from_specs(CopyDataSpec *copySpecs);
 bool catalog_register_setup_from_specs(CopyDataSpec *copySpecs);
 bool catalog_update_setup(CopyDataSpec *copySpecs);
+bool catalog_update_filters(DatabaseCatalog *catalog, const char *filters);
 
 /* snapshot.c */
 bool copydb_copy_snapshot(CopyDataSpec *specs, TransactionSnapshot *snapshot);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -81,7 +81,8 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		}
 
 		/* we might have to prepare the snapshot locally */
-		if (specs->sourceSnapshot.state == SNAPSHOT_STATE_UNKNOWN)
+		if (specs->sourceSnapshot.state == SNAPSHOT_STATE_UNKNOWN ||
+			specs->sourceSnapshot.state == SNAPSHOT_STATE_CLOSED)
 		{
 			if (!copydb_prepare_snapshot(specs))
 			{
@@ -582,6 +583,7 @@ copydb_fetch_source_schema(CopyDataSpec *specs, PGSQL *src)
 	}
 
 	if ((specs->section == DATA_SECTION_ALL ||
+		 specs->section == DATA_SECTION_SCHEMA ||
 		 specs->section == DATA_SECTION_NAMESPACES) &&
 		!sourceDB->sections[DATA_SECTION_NAMESPACES].fetched)
 	{


### PR DESCRIPTION
## Summary
- Fix concurrent database connection handling ("source is already in use")
- Fix catalog mismatch issues when using --follow mode
- Fix namespace population for DATA_SECTION_SCHEMA
- Ensure --follow works correctly with --filters

Rebased from teknogeek0/pgcopydb PRs #5, #14.