### PR TITLE
Add view and trigger tracking with failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,31 @@
 ### pgcopydb (Unreleased) ###
 
 ### Added
-* Add support for PostgreSQL 17 and 18
-* Update all test infrastructure to PostgreSQL 17
-* Update CI pipeline to test against PostgreSQL 16, 17, and 18
+* Support for PostgreSQL 17 and 18
+* New `--skip-publications` flag allows migrations to proceed when publications already exist on the source database or need to be managed separately
+* New `pgcopydb list views` command to list all views from the source database
+* New `pgcopydb list triggers` command to list all triggers from the source database with schema and table details
+* Enhanced failure reporting: When migrations fail, pgcopydb now displays a detailed summary showing completed phases, failure location, progress within the failed phase, and resource counts (tables, indexes, constraints, sequences, views, triggers)
+* Views and triggers are now tracked in internal SQLite catalogs and included in migration summaries
 
 ### Fixed
-* Fix "database source is already in use" error when using `--follow` with `--filters` (#829, #871, #910)
-* Fix catalog mismatch errors when using different commands in sequence with filters (#869, #868)
-* Fix transaction state management for `clone --follow --snapshot` workflows
-* Make catalog_attach() idempotent to prevent concurrent process conflicts
-* Tolerate minor pg_restore errors during schema restoration - pgcopydb now continues when pg_restore exits with code 1 but reports "errors ignored on restore: N" where N ≤ 10 (configurable via MAX_TOLERATED_RESTORE_ERRORS). This allows migrations to proceed through minor extension version mismatches (e.g., PostGIS 3.1.5 → 3.5.3) that don't affect data integrity.
+
+**Migrations with Filters:**
+* Migrations using `--follow` with table/schema filters now work reliably without "database source is already in use" errors (#624, #829, #871, #910)
+* Running multiple pgcopydb commands with filters in sequence no longer causes catalog conflicts
+* Filters are now correctly applied during both the initial copy and ongoing replication phases
+
+**Change Data Capture Improvements:**
+* pgcopydb now works alongside other replication tools (PeerDB, Debezium, etc.) without conflicts
+* Tables with prepared statements (PREPARE/EXECUTE) are now replicated correctly
+* JSON and JSONB columns replicate properly when using the test_decoding plugin (#919)
+
+**Schema Restoration:**
+* Migrations now continue successfully when minor extension version differences exist between source and target (e.g., PostGIS 3.1.5 → 3.5.3)
+
+**Online Migration Stability:**
+* `clone --follow --snapshot` workflows now handle transaction state correctly
+* Concurrent pgcopydb processes no longer conflict when accessing the same source database
 
 ### pgcopydb v0.17 (August 7, 2024) ###
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ $ pgcopydb help
     tables       List all the source tables to copy data from
     table-parts  List a source table copy partitions
     sequences    List all the source sequences to copy data from
+    views        List all the source views
+    triggers     List all the source triggers
     indexes      List all the indexes to create again after copying the data
     depends      List all the dependencies to filter-out
     schema       List the schema to migrate, formatted in JSON

--- a/docs/include/help.rst
+++ b/docs/include/help.rst
@@ -49,6 +49,8 @@
        tables       List all the source tables to copy data from
        table-parts  List a source table copy partitions
        sequences    List all the source sequences to copy data from
+       views        List all the source views
+       triggers     List all the source triggers
        indexes      List all the indexes to create again after copying the data
        depends      List all the dependencies to filter-out
        schema       List the schema to migrate, formatted in JSON

--- a/docs/include/list-triggers.rst
+++ b/docs/include/list-triggers.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb list triggers: List all the source triggers
+   usage: pgcopydb list triggers  --source ... [ --schema-name [ --table-name ] ]
+   
+     --source            Postgres URI to the source database
+     --force             Force fetching catalogs again
+     --schema-name       Filter by schema name
+     --table-name        Filter by table name
+     --filter <filename> Use the filters defined in <filename>
+   

--- a/docs/include/list-views.rst
+++ b/docs/include/list-views.rst
@@ -1,0 +1,9 @@
+::
+
+   pgcopydb list views: List all the source views
+   usage: pgcopydb list views  --source ... 
+   
+     --source            Postgres URI to the source database
+     --force             Force fetching catalogs again
+     --filter <filename> Use the filters defined in <filename>
+   

--- a/docs/include/list.rst
+++ b/docs/include/list.rst
@@ -10,6 +10,8 @@
        tables       List all the source tables to copy data from
        table-parts  List a source table copy partitions
        sequences    List all the source sequences to copy data from
+       views        List all the source views
+       triggers     List all the source triggers
        indexes      List all the indexes to create again after copying the data
        depends      List all the dependencies to filter-out
        schema       List the schema to migrate, formatted in JSON

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -150,6 +150,8 @@ typedef struct CatalogCounts
 	uint64_t indexes;
 	uint64_t constraints;
 	uint64_t sequences;
+	uint64_t views;
+	uint64_t triggers;
 
 	uint64_t roles;
 	uint64_t databases;
@@ -190,6 +192,62 @@ bool catalog_lookup_s_matview_by_oid(DatabaseCatalog *catalog,
 									 CatalogMatView *result,
 									 uint32_t oid);
 bool catalog_s_matview_fetch(SQLiteQuery *query);
+
+/*
+ * Views
+ */
+bool catalog_add_s_view(DatabaseCatalog *catalog, SourceView *view);
+
+bool catalog_lookup_s_view_by_oid(DatabaseCatalog *catalog,
+								  SourceView *result,
+								  uint32_t oid);
+
+typedef bool (SourceViewIterFun)(void *context, SourceView *view);
+
+typedef struct SourceViewIterator
+{
+	DatabaseCatalog *catalog;
+	SourceView *view;
+	SQLiteQuery query;
+} SourceViewIterator;
+
+bool catalog_iter_s_view(DatabaseCatalog *catalog,
+						 void *context,
+						 SourceViewIterFun *callback);
+
+bool catalog_iter_s_view_init(SourceViewIterator *iter);
+bool catalog_iter_s_view_next(SourceViewIterator *iter);
+bool catalog_iter_s_view_finish(SourceViewIterator *iter);
+
+bool catalog_s_view_fetch(SQLiteQuery *query);
+
+/*
+ * Triggers
+ */
+bool catalog_add_s_trigger(DatabaseCatalog *catalog, SourceTrigger *trigger);
+
+bool catalog_lookup_s_trigger_by_oid(DatabaseCatalog *catalog,
+									 SourceTrigger *result,
+									 uint32_t oid);
+
+typedef bool (SourceTriggerIterFun)(void *context, SourceTrigger *trigger);
+
+typedef struct SourceTriggerIterator
+{
+	DatabaseCatalog *catalog;
+	SourceTrigger *trigger;
+	SQLiteQuery query;
+} SourceTriggerIterator;
+
+bool catalog_iter_s_trigger(DatabaseCatalog *catalog,
+							void *context,
+							SourceTriggerIterFun *callback);
+
+bool catalog_iter_s_trigger_init(SourceTriggerIterator *iter);
+bool catalog_iter_s_trigger_next(SourceTriggerIterator *iter);
+bool catalog_iter_s_trigger_finish(SourceTriggerIterator *iter);
+
+bool catalog_s_trigger_fetch(SQLiteQuery *query);
 
 /*
  * Tables and their attributes and parts (COPY partitioning).

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -602,6 +602,7 @@ cloneDB(CopyDataSpec *copySpecs)
 	if (!copydb_copy_all_table_data(copySpecs))
 	{
 		/* errors have already been logged */
+		(void) summary_print_failure_report(copySpecs);
 		return false;
 	}
 
@@ -611,6 +612,7 @@ cloneDB(CopyDataSpec *copySpecs)
 	{
 		log_error("Failed to finalize schema on the target database, "
 				  "see above for details");
+		(void) summary_print_failure_report(copySpecs);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -230,6 +230,48 @@ typedef struct SourceSequence
 
 
 /*
+ * SourceView caches the information we need about all the views found
+ * in the source database.
+ */
+typedef struct SourceView
+{
+	uint32_t oid;
+	char qname[PG_NAMEDATALEN_FQ];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
+	char restoreListName[RESTORE_LIST_NAMEDATALEN];
+} SourceView;
+
+typedef struct SourceViewArray
+{
+	int count;
+	SourceView *array;          /* malloc'ed area */
+} SourceViewArray;
+
+
+/*
+ * SourceTrigger caches the information we need about all the triggers found
+ * in the source database.
+ */
+typedef struct SourceTrigger
+{
+	uint32_t oid;
+	char tgname[PG_NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
+	uint32_t tableoid;
+	char qname[PG_NAMEDATALEN_FQ];
+	char restoreListName[RESTORE_LIST_NAMEDATALEN];
+} SourceTrigger;
+
+typedef struct SourceTriggerArray
+{
+	int count;
+	SourceTrigger *array;       /* malloc'ed area */
+} SourceTriggerArray;
+
+
+/*
  * SourceIndex caches the information we need about all the indexes attached to
  * the ordinary tables found in the source database.
  */
@@ -436,6 +478,14 @@ bool schema_list_partitions(PGSQL *pgsql,
 bool schema_list_sequences(PGSQL *pgsql,
 						   SourceFilters *filters,
 						   DatabaseCatalog *catalog);
+
+bool schema_list_views(PGSQL *pgsql,
+					   SourceFilters *filters,
+					   DatabaseCatalog *catalog);
+
+bool schema_list_triggers(PGSQL *pgsql,
+						  SourceFilters *filters,
+						  DatabaseCatalog *catalog);
 
 bool schema_get_sequence_value(PGSQL *pgsql, SourceSequence *seq);
 bool schema_list_relpages(PGSQL *pgsql, SourceTable *table, DatabaseCatalog *catalog);

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -22,6 +22,9 @@
 #include "string_utils.h"
 #include "schema.h"
 
+/* forward declarations */
+typedef struct CopyDataSpec CopyDataSpec;
+
 typedef struct CopyTableSummary
 {
 	pid_t pid;                  /* pid */
@@ -190,6 +193,8 @@ bool summary_lookup_timing(DatabaseCatalog *catalog,
 
 bool summary_pretty_print_timing(DatabaseCatalog *catalog,
 								 TopLevelTiming *timing);
+
+bool summary_print_failure_report(CopyDataSpec *specs);
 
 /*
  * Summary Iterator


### PR DESCRIPTION
## Summary
- Add view and trigger tracking to the catalog with `list views` and `list triggers` commands
- Add failure reporting during schema restoration for views and triggers
- Fix duplicate s_view/s_trigger insert on clone --follow
- Add fetched guard, timing, and section registration for tracking

Rebased from teknogeek0/pgcopydb PRs #23, #31, #33.