### PR TITLE
Support filtering and clone --follow from read-only standby

### DIFF
--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -735,6 +735,7 @@ filters_from_json(const char *jsonString, SourceFilters *filters)
 
 	/* Initialize filters to empty state */
 	filters->prepared = false;
+	filters->isReadOnly = false;
 	filters->type = SOURCE_FILTER_TYPE_NONE;
 	filters->includeOnlySchemaList.count = 0;
 	filters->includeOnlySchemaList.array = NULL;
@@ -752,6 +753,7 @@ filters_from_json(const char *jsonString, SourceFilters *filters)
 	filters->includeOnlyExtensionList.array = NULL;
 	filters->excludeExtensionList.count = 0;
 	filters->excludeExtensionList.array = NULL;
+	filters->ctePreamble = NULL;
 
 	/* Parse JSON string */
 	JSON_Value *jsFilter = json_parse_string(jsonString);

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -102,6 +102,7 @@ typedef enum
 typedef struct SourceFilters
 {
 	bool prepared;
+	bool isReadOnly;
 	SourceFilterType type;
 	SourceFilterSchemaList includeOnlySchemaList;
 	SourceFilterSchemaList excludeSchemaList;
@@ -111,6 +112,7 @@ typedef struct SourceFilters
 	SourceFilterTableList excludeIndexList;
 	SourceFilterExtensionList includeOnlyExtensionList;
 	SourceFilterExtensionList excludeExtensionList;
+	char *ctePreamble;
 } SourceFilters;
 
 char * filterTypeToString(SourceFilterType type);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,9 +10,9 @@ export DOCKER
 
 BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
-all: pagila pagila-multi-steps blobs unit filtering extensions \
+all: pagila pagila-multi-steps blobs unit filtering filtering-standby extensions \
 	 cdc-wal2json cdc-test-decoding cdc-endpos-between-transaction cdc-low-level \
-	 follow-wal2json follow-9.6 follow-data-only \
+	 follow-wal2json follow-standby follow-9.6 follow-data-only \
 	 endpos-in-multi-wal-txn exclude-extension;
 
 pagila: build
@@ -33,6 +33,9 @@ unit: build
 filtering: build
 	$(MAKE) -C $@
 
+filtering-standby: build
+	$(MAKE) -C $@
+
 extensions: build
 	$(MAKE) -C $@
 
@@ -49,6 +52,9 @@ cdc-low-level: build
 	$(MAKE) -C $@
 
 follow-wal2json: build
+	$(MAKE) -C $@
+
+follow-standby: build
 	$(MAKE) -C $@
 
 follow-9.6: build
@@ -71,7 +77,7 @@ build:
 	$(DOCKER) build $(BUILD_ARGS) --build-arg PGCOPYDB_IMAGE=pgcopydb:pg$(PGVERSION) -t pagila -f Dockerfile.pagila .
 
 .PHONY: all build
-.PHONY: pagila pagila-multi-steps blobs unit filtering extensions
+.PHONY: pagila pagila-multi-steps blobs unit filtering filtering-standby extensions
 .PHONY: cdc-wal2json cdc-test-decoding cdc-low-level
-.PHONY: follow-wal2json follow-9.6
+.PHONY: follow-wal2json follow-standby follow-9.6
 .PHONY: endpos-in-multi-wal-txn exclude-extension

--- a/tests/filtering-standby/00_init_replication_slot.sql
+++ b/tests/filtering-standby/00_init_replication_slot.sql
@@ -1,0 +1,1 @@
+select pg_create_physical_replication_slot('replication_slot');

--- a/tests/filtering-standby/Dockerfile
+++ b/tests/filtering-standby/Dockerfile
@@ -1,0 +1,18 @@
+# that image is built by docker compose build: project-service
+FROM pagila
+
+COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./exclude.ini exclude.ini
+COPY ./include.ini include.ini
+COPY ./extra.sql extra.sql
+
+# validation queries
+COPY ./exclude ./test/exclude
+COPY ./include ./test/include
+
+USER docker
+WORKDIR /usr/src/pgcopydb/test/
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/filtering-standby/Makefile
+++ b/tests/filtering-standby/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+.PHONY: run down build test

--- a/tests/filtering-standby/compose.yaml
+++ b/tests/filtering-standby/compose.yaml
@@ -1,0 +1,96 @@
+x-postgres-base-env: &x-postgres-base-env
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: h4ckm3
+  POSTGRES_DB: pagila
+  POSTGRES_HOST_AUTH_METHOD: "trust"
+
+x-postgres-base-env-allow-replication: &x-postgres-base-env-allow-replication
+  <<: *x-postgres-base-env
+  POSTGRES_HOST_AUTH_METHOD: "trust\nhost replication all 0.0.0.0/0 trust"
+
+x-postgres-base: &x-postgres-base
+    image: postgres:${PGVERSION:-16}
+    user: postgres
+    expose:
+      - 5432
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+services:
+  source:
+    <<: *x-postgres-base
+    environment:
+        <<: *x-postgres-base-env-allow-replication
+    command: |
+      postgres
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+      -c wal_level=replica
+      -c hot_standby=on
+      -c max_wal_senders=10
+      -c max_replication_slots=10
+      -c hot_standby_feedback=on
+    volumes:
+      - ./00_init_replication_slot.sql:/docker-entrypoint-initdb.d/00_init_replication_slot.sql
+
+  source-standby:
+    <<: *x-postgres-base
+    environment:
+        <<: *x-postgres-base-env
+    command: |
+     bash -c '
+      until pg_basebackup --pgdata="$$PGDATA" -R --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila
+      do
+      echo "Waiting for primary to connect..."
+      sleep 1s
+      done
+      echo "Backup done, starting replica..."
+      chmod 0700 "$$PGDATA"
+      postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+     '
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      source:
+        condition: service_healthy
+
+  target:
+    <<: *x-postgres-base
+    environment:
+      <<: *x-postgres-base-env
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/pagila
+      PGCOPYDB_SOURCE_STANDBY_PGURI: postgres://postgres:h4ckm3@source-standby/pagila
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/pagila
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 4
+      PGCOPYDB_LARGE_OBJECTS_JOBS: 4
+      PGCOPYDB_FAIL_FAST: "true"
+    depends_on:
+      source:
+        condition: service_healthy
+      source-standby:
+        condition: service_healthy
+      target:
+        condition: service_healthy

--- a/tests/filtering-standby/copydb.sh
+++ b/tests/filtering-standby/copydb.sh
@@ -1,0 +1,118 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_SOURCE_STANDBY_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# sleep 5 seconds to make sure standby is ready
+sleep 5
+
+# Load schema and data on the primary (writable) source
+grep -v "OWNER TO postgres" /usr/src/pagila/pagila-schema.sql > /tmp/pagila-schema.sql
+
+psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
+psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+psql -o /tmp/e.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/extra.sql
+
+# Wait for standby to catch up with the primary
+sleep 5
+
+# Verify the standby is indeed read-only
+psql -d ${PGCOPYDB_SOURCE_STANDBY_PGURI} -c "SELECT pg_is_in_recovery();"
+
+# ============================================================
+# TEST 1: Clone from standby with EXCLUDE filters
+# ============================================================
+export TMPDIR=/tmp/exclude
+
+# list the exclude filters now, and the computed dependencies
+cat /usr/src/pgcopydb/exclude.ini
+
+# list the tables that are (not) selected by the filters
+pgcopydb list tables --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/exclude.ini
+pgcopydb list tables --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/exclude.ini --list-skipped
+
+# list the dependencies of objects that are not selected by the filters
+pgcopydb list depends --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/exclude.ini --list-skipped
+
+# list the sequences that are (not) selected by the filters
+pgcopydb list sequences --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/exclude.ini
+pgcopydb list sequences --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/exclude.ini --list-skipped
+
+pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini --skip-ext-comments --notice \
+         --resume --not-consistent \
+         --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --target ${PGCOPYDB_TARGET_PGURI}
+
+# Validate exclude filter results
+mkdir -p /tmp/results
+
+pgopts="--single-transaction --no-psqlrc --expanded"
+
+for f in ./exclude/sql/*.sql
+do
+    t=`basename $f .sql`
+    r=/tmp/results/${t}.out
+    e=./exclude/expected/${t}.out
+    psql -d "${PGCOPYDB_TARGET_PGURI}" ${pgopts} --file ./exclude/sql/$t.sql &> $r
+    test -f $e || cat $r
+    diff -urN $e $r || cat $e $r
+    diff -urN $e $r || exit 1
+done
+
+echo "EXCLUDE filter tests on standby: PASSED"
+
+# ============================================================
+# TEST 2: Clone from standby with INCLUDE filters
+# ============================================================
+
+# Drop and recreate target database for a clean include test
+psql -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'pagila' AND pid <> pg_backend_pid();" || true
+dropdb -U postgres -h target pagila || true
+createdb -U postgres -h target pagila
+
+export TMPDIR=/tmp/include
+
+# list the tables that are (not) selected by the filters
+pgcopydb list tables --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/include.ini
+pgcopydb list tables --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --filters /usr/src/pgcopydb/include.ini --list-skipped
+
+pgcopydb clone --filters /usr/src/pgcopydb/include.ini --skip-ext-comments --notice \
+         --resume --not-consistent \
+         --source ${PGCOPYDB_SOURCE_STANDBY_PGURI} \
+         --target ${PGCOPYDB_TARGET_PGURI}
+
+# Validate include filter results
+for f in ./include/sql/*.sql
+do
+    t=`basename $f .sql`
+    r=/tmp/results/${t}.out
+    e=./include/expected/${t}.out
+    psql -d "${PGCOPYDB_TARGET_PGURI}" ${pgopts} --file ./include/sql/$t.sql &> $r
+    test -f $e || cat $r
+    diff -urN $e $r || cat $e $r
+    diff -urN $e $r || exit 1
+done
+
+echo "INCLUDE filter tests on standby: PASSED"
+echo "All filtering-standby tests: PASSED"

--- a/tests/filtering-standby/exclude.ini
+++ b/tests/filtering-standby/exclude.ini
@@ -1,0 +1,9 @@
+[exclude-schema]
+public
+bar
+
+[exclude-table]
+foo.tbl2
+
+[exclude-table-data]
+foo.tbl_status

--- a/tests/filtering-standby/exclude/expected/1-schema-bar-excluded.out
+++ b/tests/filtering-standby/exclude/expected/1-schema-bar-excluded.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+exists | f
+

--- a/tests/filtering-standby/exclude/expected/2-schema-public-excluded.out
+++ b/tests/filtering-standby/exclude/expected/2-schema-public-excluded.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+count | 0
+

--- a/tests/filtering-standby/exclude/expected/3-table-tbl2-excluded.out
+++ b/tests/filtering-standby/exclude/expected/3-table-tbl2-excluded.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+exists | f
+

--- a/tests/filtering-standby/exclude/expected/4-table-data-excluded.out
+++ b/tests/filtering-standby/exclude/expected/4-table-data-excluded.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+count | 0
+

--- a/tests/filtering-standby/exclude/expected/5-sequences-copied.out
+++ b/tests/filtering-standby/exclude/expected/5-sequences-copied.out
@@ -1,0 +1,9 @@
+-[ RECORD 1 ]---
+last_value | 667
+
+-[ RECORD 1 ]---
+last_value | 668
+
+-[ RECORD 1 ]---
+last_value | 669
+

--- a/tests/filtering-standby/exclude/sql/1-schema-bar-excluded.sql
+++ b/tests/filtering-standby/exclude/sql/1-schema-bar-excluded.sql
@@ -1,0 +1,2 @@
+-- Schema 'bar' should not exist on target (it was excluded)
+select exists(select 1 from pg_namespace where nspname = 'bar');

--- a/tests/filtering-standby/exclude/sql/2-schema-public-excluded.sql
+++ b/tests/filtering-standby/exclude/sql/2-schema-public-excluded.sql
@@ -1,0 +1,5 @@
+-- No public tables should exist on target (public schema was excluded)
+select count(*)
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+ where n.nspname = 'public' and c.relkind = 'r';

--- a/tests/filtering-standby/exclude/sql/3-table-tbl2-excluded.sql
+++ b/tests/filtering-standby/exclude/sql/3-table-tbl2-excluded.sql
@@ -1,0 +1,6 @@
+-- foo.tbl2 should not exist on target (it was excluded)
+select exists(
+    select 1 from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'foo' and c.relname = 'tbl2'
+);

--- a/tests/filtering-standby/exclude/sql/4-table-data-excluded.sql
+++ b/tests/filtering-standby/exclude/sql/4-table-data-excluded.sql
@@ -1,0 +1,2 @@
+-- foo.tbl_status should exist but have no data (exclude-table-data)
+select count(*) from foo.tbl_status;

--- a/tests/filtering-standby/exclude/sql/5-sequences-copied.sql
+++ b/tests/filtering-standby/exclude/sql/5-sequences-copied.sql
@@ -1,0 +1,4 @@
+-- Sequences in non-excluded schemas should be copied with their values
+select last_value from seq.default_table_id_seq;
+select last_value from seq.identity_table_id_seq;
+select last_value from seq.standalone_id_seq;

--- a/tests/filtering-standby/extra.sql
+++ b/tests/filtering-standby/extra.sql
@@ -1,0 +1,58 @@
+--
+-- Extra schemas and tables for filtering tests on a standby
+--
+
+create schema foo;
+
+create table foo.tbl_status (
+    id bigserial not null primary key,
+    name varchar(32) not null unique check (name != '')
+);
+
+insert into foo.tbl_status (id, name)
+     values (1, 'draft'),
+            (2, 'active'),
+            (3, 'closed');
+
+SELECT setval(pg_get_serial_sequence('foo.tbl_status', 'id'),
+              (SELECT COALESCE(MAX(id) + 1, 1) FROM foo.tbl_status),
+              false);
+
+create table foo.tbl1 (
+    id bigserial not null primary key,
+    status_id bigint not null default 1 references foo.tbl_status(id),
+    desc_text varchar(32)
+);
+
+create index if not exists tbl1_status_id_idx on foo.tbl1(status_id);
+
+create table foo.tbl2 (
+    id bigserial not null primary key,
+    tbl1_id bigint not null references foo.tbl1(id),
+    desc_text varchar(32)
+);
+
+create index if not exists tbl2_tbl1_id_idx on foo.tbl2(tbl1_id);
+
+--
+-- A schema to exclude wholesale
+--
+create schema bar;
+
+create table bar.should_not_exist (id serial primary key, val text);
+insert into bar.should_not_exist (val) values ('this should be filtered out');
+
+--
+-- Sequences in their own schema
+--
+create schema seq;
+
+create sequence seq.default_table_id_seq;
+create table seq.default_table (id integer primary key default nextval('seq.default_table_id_seq'));
+select setval('seq.default_table_id_seq', 667);
+
+create table seq.identity_table (id integer primary key generated always as identity);
+select setval('seq.identity_table_id_seq', 668);
+
+create sequence seq.standalone_id_seq;
+select setval('seq.standalone_id_seq', 669);

--- a/tests/filtering-standby/include.ini
+++ b/tests/filtering-standby/include.ini
@@ -1,0 +1,11 @@
+[include-only-table]
+foo.tbl_status
+foo.tbl1
+seq.default_table
+seq.identity_table
+
+[exclude-index]
+foo.tbl1_status_id_idx
+
+[exclude-table-data]
+foo.tbl1

--- a/tests/filtering-standby/include/expected/1-only-included-tables.out
+++ b/tests/filtering-standby/include/expected/1-only-included-tables.out
@@ -1,0 +1,13 @@
+-[ RECORD 1 ]-----------
+nspname | foo
+relname | tbl1
+-[ RECORD 2 ]-----------
+nspname | foo
+relname | tbl_status
+-[ RECORD 3 ]-----------
+nspname | seq
+relname | default_table
+-[ RECORD 4 ]-----------
+nspname | seq
+relname | identity_table
+

--- a/tests/filtering-standby/include/expected/2-tbl1-data-excluded.out
+++ b/tests/filtering-standby/include/expected/2-tbl1-data-excluded.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+count | 0
+

--- a/tests/filtering-standby/include/expected/3-tbl_status-has-data.out
+++ b/tests/filtering-standby/include/expected/3-tbl_status-has-data.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+count | 3
+

--- a/tests/filtering-standby/include/expected/4-exclude-index.out
+++ b/tests/filtering-standby/include/expected/4-exclude-index.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+exists | f
+

--- a/tests/filtering-standby/include/sql/1-only-included-tables.sql
+++ b/tests/filtering-standby/include/sql/1-only-included-tables.sql
@@ -1,0 +1,7 @@
+-- Only the 4 included tables should exist
+  select n.nspname, c.relname
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where c.relkind = 'r'
+     and n.nspname not in ('pg_catalog', 'information_schema')
+order by n.nspname, c.relname;

--- a/tests/filtering-standby/include/sql/2-tbl1-data-excluded.sql
+++ b/tests/filtering-standby/include/sql/2-tbl1-data-excluded.sql
@@ -1,0 +1,2 @@
+-- foo.tbl1 should exist but have no data (exclude-table-data)
+select count(*) from foo.tbl1;

--- a/tests/filtering-standby/include/sql/3-tbl_status-has-data.sql
+++ b/tests/filtering-standby/include/sql/3-tbl_status-has-data.sql
@@ -1,0 +1,2 @@
+-- foo.tbl_status should have its data (not excluded from data copy)
+select count(*) from foo.tbl_status;

--- a/tests/filtering-standby/include/sql/4-exclude-index.sql
+++ b/tests/filtering-standby/include/sql/4-exclude-index.sql
@@ -1,0 +1,7 @@
+-- tbl1_status_id_idx should not exist (it was in exclude-index)
+select exists(
+    select 1 from pg_indexes
+    where schemaname = 'foo'
+      and tablename = 'tbl1'
+      and indexname = 'tbl1_status_id_idx'
+);

--- a/tests/follow-standby/00_init_replication_slot.sql
+++ b/tests/follow-standby/00_init_replication_slot.sql
@@ -1,0 +1,1 @@
+select pg_create_physical_replication_slot('replication_slot');

--- a/tests/follow-standby/Dockerfile
+++ b/tests/follow-standby/Dockerfile
@@ -1,0 +1,9 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./dml.sql dml.sql
+COPY ./ddl.sql ddl.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/follow-standby/Dockerfile.inject
+++ b/tests/follow-standby/Dockerfile.inject
@@ -1,0 +1,14 @@
+FROM pgcopydb
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/pgcopydb
+COPY ./inject.sh inject.sh
+COPY ./dml.sql dml.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/inject.sh"]

--- a/tests/follow-standby/Dockerfile.pg
+++ b/tests/follow-standby/Dockerfile.pg
@@ -1,0 +1,9 @@
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
+
+ARG PGVERSION=16
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
+    && rm -rf /var/lib/apt/lists/*
+USER postgres

--- a/tests/follow-standby/Makefile
+++ b/tests/follow-standby/Makefile
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	$(DOCKER) compose up $(COMPOSE_EXIT)
+
+run: build fix-volumes
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+VPATH   = /var/run/pgcopydb
+CNAME   = follow-standby
+VNAME   = follow-standby
+VOLUMES = -v $(VNAME):$(VPATH)
+OPTS    = --env-file=../paths.env $(VOLUMES)
+CLEANUP = make -f /var/lib/postgres/cleanup.mk
+
+fix-volumes:
+	$(DOCKER) run --rm $(OPTS) $(CNAME) $(CLEANUP)
+
+attach:
+	$(DOCKER) run --rm -it $(OPTS) $(CNAME) bash
+
+.PHONY: run down build test fix-volumes

--- a/tests/follow-standby/compose.yaml
+++ b/tests/follow-standby/compose.yaml
@@ -1,0 +1,130 @@
+x-postgres-base-env: &x-postgres-base-env
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: h4ckm3
+  POSTGRES_DB: pagila
+  POSTGRES_HOST_AUTH_METHOD: "trust"
+
+x-postgres-base-env-allow-replication: &x-postgres-base-env-allow-replication
+  <<: *x-postgres-base-env
+  POSTGRES_HOST_AUTH_METHOD: "trust\nhost replication all 0.0.0.0/0 trust"
+
+x-postgres-wal2json: &x-postgres-wal2json
+    image: postgres-wal2json
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+      args:
+        PGVERSION: ${PGVERSION:-16}
+    user: postgres
+    expose:
+      - 5432
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+services:
+  source:
+    <<: *x-postgres-wal2json
+    environment:
+        <<: *x-postgres-base-env-allow-replication
+    command: |
+      postgres
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+      -c wal_level=logical
+      -c hot_standby=on
+      -c max_wal_senders=10
+      -c max_replication_slots=10
+      -c hot_standby_feedback=on
+    volumes:
+      - ./00_init_replication_slot.sql:/docker-entrypoint-initdb.d/00_init_replication_slot.sql
+
+  source-standby:
+    <<: *x-postgres-wal2json
+    environment:
+        <<: *x-postgres-base-env
+    command: |
+     bash -c '
+      until pg_basebackup --pgdata="$$PGDATA" -R --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila
+      do
+      echo "Waiting for primary to connect..."
+      sleep 1s
+      done
+      echo "Backup done, starting replica..."
+      chmod 0700 "$$PGDATA"
+      postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key -c hot_standby_feedback=on -c wal_level=logical -c max_replication_slots=10
+     '
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      source:
+        condition: service_healthy
+
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      <<: *x-postgres-base-env
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  inject:
+    build:
+      context: .
+      dockerfile: Dockerfile.inject
+    environment:
+      PGCOPYDB_PRIMARY_PGURI: "postgres://postgres:h4ckm3@source/pagila"
+      PGCOPYDB_SOURCE_PGURI: "postgres://postgres:h4ckm3@source-standby/pagila"
+      PGCOPYDB_TARGET_PGURI: "postgres://postgres:h4ckm3@target/pagila"
+    env_file:
+      - ../paths.env
+    # share TMPDIR between inject and test services
+    volumes:
+      - follow-standby:/var/run/pgcopydb
+
+  test:
+    image: follow-standby
+    build: .
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_PRIMARY_PGURI: "postgres://postgres:h4ckm3@source/pagila"
+      PGCOPYDB_SOURCE_PGURI: "postgres://postgres:h4ckm3@source-standby/pagila"
+      PGCOPYDB_TARGET_PGURI: "postgres://postgres:h4ckm3@target/pagila"
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+    env_file:
+      - ../paths.env
+    # share TMPDIR between inject and test services
+    volumes:
+      - follow-standby:/var/run/pgcopydb
+    depends_on:
+      source:
+        condition: service_healthy
+      source-standby:
+        condition: service_healthy
+      target:
+        condition: service_healthy
+      inject:
+        condition: service_started
+
+volumes:
+  follow-standby:
+    external: true

--- a/tests/follow-standby/copydb.sh
+++ b/tests/follow-standby/copydb.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_PRIMARY_PGURI     (primary for schema setup)
+#  - PGCOPYDB_SOURCE_PGURI      (standby for pgcopydb clone)
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# make sure source (standby) and target databases are ready
+pgcopydb ping
+
+# wait for the standby to be fully caught up with the primary
+sleep 5
+
+# load pagila schema and data on the PRIMARY (standby replicates it)
+psql -o /tmp/s.out -d ${PGCOPYDB_PRIMARY_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/d.out -d ${PGCOPYDB_PRIMARY_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+
+# alter the pagila schema to allow capturing DDLs without pkey
+psql -d ${PGCOPYDB_PRIMARY_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# wait for the standby to replicate the schema and data
+sleep 5
+
+# pgcopydb clone --follow from the standby (PG16+ logical replication)
+pgcopydb clone --follow --plugin wal2json
+
+# show final sentinel values
+pgcopydb stream sentinel get
+
+# make sure the inject service has had time to see the final sentinel values
+sleep 2
+
+# NOTE: pgcopydb stream cleanup is NOT called here because it runs
+# DROP SCHEMA IF EXISTS on the source, which fails on a read-only standby.
+# The containers are ephemeral so cleanup is handled by docker-compose down.

--- a/tests/follow-standby/ddl.sql
+++ b/tests/follow-standby/ddl.sql
@@ -1,0 +1,14 @@
+---
+--- pgcopydb test/cdc/ddl.sql
+---
+--- This file implements DDL changes in the pagila database.
+
+begin;
+alter table payment_p2022_01 replica identity full;
+alter table payment_p2022_02 replica identity full;
+alter table payment_p2022_03 replica identity full;
+alter table payment_p2022_04 replica identity full;
+alter table payment_p2022_05 replica identity full;
+alter table payment_p2022_06 replica identity full;
+alter table payment_p2022_07 replica identity full;
+commit;

--- a/tests/follow-standby/dml.sql
+++ b/tests/follow-standby/dml.sql
@@ -1,0 +1,50 @@
+---
+--- pgcopydb test/cdc/dml.sql
+---
+--- This file implements DML changes in the pagila database.
+
+\set customerid1 291
+\set customerid2 292
+
+\set staffid1 1
+\set staffid2 2
+
+\set inventoryid1 371
+\set inventoryid2 1097
+
+begin;
+
+with r as
+ (
+   insert into rental(rental_date, inventory_id, customer_id, staff_id, last_update)
+        select '2022-06-01', :inventoryid1, :customerid1, :staffid1, '2022-06-01'
+     returning rental_id, customer_id, staff_id
+ )
+ insert into payment(customer_id, staff_id, rental_id, amount, payment_date)
+      select customer_id, staff_id, rental_id, 5.99, '2022-06-01'
+        from r;
+
+commit;
+
+-- update 10 rows in a single UPDATE command
+update public.payment set amount = 11.95 where amount = 11.99;
+
+begin;
+
+delete from payment
+      using rental
+      where rental.rental_id = payment.rental_id
+        and rental.last_update = '2022-06-01';
+
+delete from rental where rental.last_update = '2022-06-01';
+
+commit;
+
+--
+-- update the payments back to their original values
+--
+begin;
+
+update public.payment set amount = 11.99 where amount = 11.95;
+
+commit;

--- a/tests/follow-standby/inject.sh
+++ b/tests/follow-standby/inject.sh
@@ -1,0 +1,90 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_PRIMARY_PGURI     (primary for DML writes and WAL queries)
+#  - PGCOPYDB_SOURCE_PGURI      (standby, used by pgcopydb sentinel commands)
+#  - PGCOPYDB_TARGET_PGURI
+
+pgcopydb ping
+
+#
+# Only start injecting DML traffic on the source database when the pagila
+# schema and base data set has been deployed already. Our proxy to know that
+# that's the case is the existence of the pgcopydb.sentinel table on the
+# source database.
+#
+dbfile=${TMPDIR}/pgcopydb/schema/source.db
+
+until [ -s ${dbfile} ]
+do
+    sleep 1
+done
+
+#
+# Inject changes from our DML file in a loop, again and again.
+#
+# DML writes and pg_switch_wal go to the PRIMARY since the standby is
+# read-only. The WAL changes replicate to the standby and pgcopydb picks
+# them up via logical decoding from the standby.
+#
+# We use longer sleeps than the primary-source test to give the standby
+# time to receive, replay, and decode the WAL changes.
+#
+for i in `seq 5`
+do
+    psql -d ${PGCOPYDB_PRIMARY_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 2
+
+    psql -d ${PGCOPYDB_PRIMARY_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 2
+
+    psql -d ${PGCOPYDB_PRIMARY_PGURI} -c 'select pg_switch_wal()'
+    sleep 2
+done
+
+# Do one final DML write after the last pg_switch_wal so that the endpos
+# WAL segment contains actual DML. Without this, the endpos lands in an
+# empty WAL segment and pgcopydb replay can't advance through it.
+psql -d ${PGCOPYDB_PRIMARY_PGURI} -f /usr/src/pgcopydb/dml.sql
+
+# Wait for the standby to replay all WAL from the primary
+sleep 5
+
+# Grab the current LSN from the PRIMARY
+lsn=`psql -At -d ${PGCOPYDB_PRIMARY_PGURI} -c 'select pg_current_wal_flush_lsn()'`
+
+# Set endpos with the explicit LSN value (cannot use --current because that
+# would call pg_current_wal_flush_lsn on the standby which fails)
+pgcopydb stream sentinel set endpos ${lsn}
+pgcopydb stream sentinel get
+
+endpos=`pgcopydb stream sentinel get --endpos 2>/dev/null`
+
+if [ ${endpos} = "0/0" ]
+then
+    echo "expected ${lsn} endpos, found ${endpos}"
+    exit 1
+fi
+
+#
+# Because we're using docker-compose --abort-on-container-exit make sure
+# that the other process in the pgcopydb service is done before exiting
+# here.
+#
+flushlsn="0/0"
+
+while [ ${flushlsn} \< ${endpos} ]
+do
+    flushlsn=`pgcopydb stream sentinel get --flush-lsn 2>/dev/null`
+    sleep 1
+done
+
+#
+# Still give some time to the pgcopydb service to finish its processing,
+# with the cleanup and all.
+#
+sleep 10


### PR DESCRIPTION
## Summary
- Support filtering queries on read-only source replicas using CTEs
- Fix read-only detection for list commands and normalize free guards
- Fix read-only transaction mode for clone --follow from standby
- Add filtering-standby and follow-standby integration tests

Rebased from teknogeek0/pgcopydb PRs #32, #35.