### PR TITLE
Fix CDC replay filtering, materialized view skip, and pipeline crashes

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -193,6 +193,23 @@ bool catalog_lookup_s_matview_by_oid(DatabaseCatalog *catalog,
 									 uint32_t oid);
 bool catalog_s_matview_fetch(SQLiteQuery *query);
 
+typedef bool (CatalogMatViewIterFun)(void *context, CatalogMatView *matview);
+
+typedef struct CatalogMatViewIterator
+{
+	DatabaseCatalog *catalog;
+	CatalogMatView *matview;
+	SQLiteQuery query;
+} CatalogMatViewIterator;
+
+bool catalog_iter_s_matview(DatabaseCatalog *catalog,
+							void *context,
+							CatalogMatViewIterFun *callback);
+
+bool catalog_iter_s_matview_init(CatalogMatViewIterator *iter);
+bool catalog_iter_s_matview_next(CatalogMatViewIterator *iter);
+bool catalog_iter_s_matview_finish(CatalogMatViewIterator *iter);
+
 /*
  * Views
  */

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -211,6 +211,7 @@ clone_and_follow(CopyDataSpec *copySpecs)
 						   copyDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
 						   &(copySpecs->catalogs.source),
+						   &(copySpecs->filters),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
 						   logSQL))
@@ -389,6 +390,7 @@ cli_follow(int argc, char **argv)
 						   copyDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
 						   &(copySpecs.catalogs.source),
+						   &(copySpecs.filters),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
 						   logSQL))

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -323,6 +323,7 @@ cli_create_snapshot(int argc, char **argv)
 							   createSNoptions.endpos,
 							   STREAM_MODE_CATCHUP,
 							   &(copySpecs.catalogs.source),
+							   &(copySpecs.filters),
 							   createSNoptions.stdIn,
 							   createSNoptions.stdOut,
 							   logSQL))

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -120,5 +120,6 @@ SourceFilterType filterTypeComplement(SourceFilterType type);
 bool parse_filters(const char *filebname, SourceFilters *filters);
 
 bool filters_as_json(SourceFilters *filters, JSON_Value *jsFilter);
+bool filters_from_json(const char *jsonString, SourceFilters *filters);
 
 #endif  /* FILTERING_H */

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -145,7 +145,7 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 
 	LogicalMessageMetadata metadata = { 0 };
 
-	if (!parseSQLAction((char *) line, &metadata))
+	if (!parseSQLAction((char *) line, &metadata, context->filters))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -49,6 +49,7 @@ stream_init_specs(StreamSpecs *specs,
 				  uint64_t endpos,
 				  LogicalStreamMode mode,
 				  DatabaseCatalog *sourceDB,
+				  SourceFilters *filters,
 				  bool stdin,
 				  bool stdout,
 				  bool logSQL)
@@ -61,6 +62,7 @@ stream_init_specs(StreamSpecs *specs,
 
 	specs->paths = *paths;
 	specs->endpos = endpos;
+	specs->filters = filters;
 
 	/*
 	 * Open the specified sourceDB catalog.
@@ -102,7 +104,7 @@ stream_init_specs(StreamSpecs *specs,
 		{
 			KeyVal options = {
 				/* we ignore the last keyword and value if the option is not set */
-				.count = specs->slot.wal2jsonNumericAsString ? 7 : 6,
+				.count = specs->slot.wal2jsonNumericAsString ? 8 : 7,
 				.keywords = {
 					"format-version",
 					"include-xids",
@@ -110,6 +112,7 @@ stream_init_specs(StreamSpecs *specs,
 					"include-transaction",
 					"include-types",
 					"filter-tables",
+					"add-msg-prefixes",
 					"numeric-data-types-as-string"
 				},
 				.values = {
@@ -119,6 +122,7 @@ stream_init_specs(StreamSpecs *specs,
 					"true",
 					"true",
 					"pgcopydb.*",
+					"pgcopydb",
 					"true"
 				}
 			};

--- a/tests/cdc-filtering/Dockerfile
+++ b/tests/cdc-filtering/Dockerfile
@@ -1,0 +1,12 @@
+FROM pgcopydb
+
+USER docker
+WORKDIR /usr/src/pgcopydb
+
+COPY --chmod=755 ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+COPY ./dml.sql dml.sql
+COPY ./verify.sql verify.sql
+COPY ./filters.ini filters.ini
+
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/cdc-filtering/Makefile
+++ b/tests/cdc-filtering/Makefile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	$(DOCKER) compose up $(COMPOSE_EXIT)
+
+run: build
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+.PHONY: run down build test

--- a/tests/cdc-filtering/compose.yaml
+++ b/tests/cdc-filtering/compose.yaml
@@ -1,0 +1,42 @@
+services:
+  source:
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+      PGCOPYDB_OUTPUT_PLUGIN: wal2json
+    depends_on:
+      - source
+      - target

--- a/tests/cdc-filtering/copydb.sh
+++ b/tests/cdc-filtering/copydb.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# Setup source database with multiple schemas and data
+psql -o /tmp/ddl.out -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# create the replication slot that captures all the changes
+coproc ( pgcopydb snapshot --follow )
+
+sleep 1
+
+# now setup the replication origin (target) and the pgcopydb.sentinel (source)
+pgcopydb stream setup
+
+# pgcopydb clone uses the environment variables
+pgcopydb clone --filters /usr/src/pgcopydb/filters.ini
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
+
+# now that the copying is done, inject CDC changes to BOTH included and excluded schemas
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+
+# grab the current LSN, it's going to be our streaming end position
+lsn=`psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_lsn()'`
+
+# prefetch the changes captured in our replication slot
+pgcopydb stream prefetch --resume --endpos "${lsn}" -vv
+
+# now allow for replaying/catching-up changes
+pgcopydb stream sentinel set apply
+
+# now apply the CDC changes to the target database
+# (filters are already stored in the catalog from the clone step)
+pgcopydb stream catchup --resume --endpos "${lsn}" -vv
+
+# Verify that excluded schemas do not exist and included data is correct
+psql -d ${PGCOPYDB_TARGET_PGURI} -f /usr/src/pgcopydb/verify.sql
+
+# cleanup
+pgcopydb stream cleanup

--- a/tests/cdc-filtering/ddl.sql
+++ b/tests/cdc-filtering/ddl.sql
@@ -1,0 +1,58 @@
+-- Create multiple schemas to test filtering
+CREATE SCHEMA IF NOT EXISTS public;
+CREATE SCHEMA IF NOT EXISTS cron;
+CREATE SCHEMA IF NOT EXISTS excluded_schema;
+
+-- Create tables in public schema (should be included)
+CREATE TABLE public.users (
+    id serial PRIMARY KEY,
+    username text NOT NULL,
+    email text
+);
+
+CREATE TABLE public.orders (
+    id serial PRIMARY KEY,
+    user_id int REFERENCES public.users(id),
+    amount numeric
+);
+
+-- Create tables in cron schema (should be excluded)
+CREATE TABLE cron.job_run_details (
+    id serial PRIMARY KEY,
+    job_id int NOT NULL,
+    run_time timestamp DEFAULT now(),
+    status text
+);
+
+CREATE TABLE cron.scheduled_jobs (
+    id serial PRIMARY KEY,
+    job_name text NOT NULL,
+    schedule text
+);
+
+-- Create tables in excluded_schema (should be excluded)
+CREATE TABLE excluded_schema.test_table (
+    id serial PRIMARY KEY,
+    data text
+);
+
+-- Insert initial data in public schema
+INSERT INTO public.users (username, email) VALUES
+    ('alice', 'alice@example.com'),
+    ('bob', 'bob@example.com'),
+    ('charlie', 'charlie@example.com');
+
+INSERT INTO public.orders (user_id, amount) VALUES
+    (1, 100.50),
+    (2, 250.75);
+
+-- Insert initial data in excluded schemas
+INSERT INTO cron.job_run_details (job_id, status) VALUES
+    (1, 'completed'),
+    (2, 'failed');
+
+INSERT INTO cron.scheduled_jobs (job_name, schedule) VALUES
+    ('cleanup', '0 0 * * *');
+
+INSERT INTO excluded_schema.test_table (data) VALUES
+    ('should not be copied');

--- a/tests/cdc-filtering/dml.sql
+++ b/tests/cdc-filtering/dml.sql
@@ -1,0 +1,32 @@
+-- CDC changes to public schema (should be applied)
+INSERT INTO public.users (username, email) VALUES
+    ('dave', 'dave@example.com'),
+    ('eve', 'eve@example.com');
+
+UPDATE public.users SET email = 'alice.new@example.com' WHERE username = 'alice';
+
+DELETE FROM public.orders WHERE id = 1;
+
+INSERT INTO public.orders (user_id, amount) VALUES
+    (3, 500.00);
+
+-- CDC changes to cron schema (should be FILTERED OUT)
+INSERT INTO cron.job_run_details (job_id, status) VALUES
+    (3, 'running'),
+    (4, 'pending');
+
+UPDATE cron.job_run_details SET status = 'completed' WHERE job_id = 2;
+
+DELETE FROM cron.scheduled_jobs WHERE id = 1;
+
+INSERT INTO cron.scheduled_jobs (job_name, schedule) VALUES
+    ('backup', '0 2 * * *');
+
+-- CDC changes to excluded_schema (should be FILTERED OUT)
+INSERT INTO excluded_schema.test_table (data) VALUES
+    ('this should not appear on target');
+
+UPDATE excluded_schema.test_table SET data = 'updated but should not appear' WHERE id = 1;
+
+-- More public changes (should be applied)
+UPDATE public.users SET username = 'robert' WHERE username = 'bob';

--- a/tests/cdc-filtering/filters.ini
+++ b/tests/cdc-filtering/filters.ini
@@ -1,0 +1,3 @@
+[exclude-schema]
+cron
+excluded_schema

--- a/tests/cdc-filtering/verify.sql
+++ b/tests/cdc-filtering/verify.sql
@@ -1,0 +1,30 @@
+-- Verify public schema data was copied AND CDC changes were applied
+SELECT 'Checking public.users' as test;
+SELECT count(*) as user_count FROM public.users;
+-- Should be 5 (3 initial + 2 from CDC)
+
+SELECT 'Checking alice email update' as test;
+SELECT email FROM public.users WHERE username = 'alice';
+-- Should be 'alice.new@example.com' (updated via CDC)
+
+SELECT 'Checking bob username update' as test;
+SELECT username FROM public.users WHERE username = 'robert';
+-- Should exist (bob was renamed to robert via CDC)
+
+SELECT 'Checking public.orders' as test;
+SELECT count(*) as order_count FROM public.orders;
+-- Should be 2 (2 initial - 1 deleted + 1 inserted via CDC)
+
+-- Verify cron schema was EXCLUDED (should not exist on target)
+SELECT 'Checking cron schema exclusion' as test;
+SELECT count(*) as cron_schema_exists
+FROM information_schema.schemata
+WHERE schema_name = 'cron';
+-- Should be 0 (schema should not exist)
+
+-- Verify excluded_schema was EXCLUDED (should not exist on target)
+SELECT 'Checking excluded_schema exclusion' as test;
+SELECT count(*) as excluded_schema_exists
+FROM information_schema.schemata
+WHERE schema_name = 'excluded_schema';
+-- Should be 0 (schema should not exist)

--- a/tests/cdc-message-handling/Dockerfile
+++ b/tests/cdc-message-handling/Dockerfile
@@ -1,0 +1,8 @@
+FROM pgcopydb
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/cdc-message-handling/Makefile
+++ b/tests/cdc-message-handling/Makefile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	$(DOCKER) compose up $(COMPOSE_EXIT)
+
+run: build
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+.PHONY: run down build test

--- a/tests/cdc-message-handling/compose.yaml
+++ b/tests/cdc-message-handling/compose.yaml
@@ -1,0 +1,42 @@
+services:
+  source:
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+      PGCOPYDB_OUTPUT_PLUGIN: wal2json
+    depends_on:
+      - source
+      - target

--- a/tests/cdc-message-handling/copydb.sh
+++ b/tests/cdc-message-handling/copydb.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# Create test schema
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# Send messages from various "tools" (these should be filtered by wal2json)
+psql -d ${PGCOPYDB_SOURCE_PGURI} <<'SQL'
+SELECT pg_logical_emit_message(false, 'peerdb_heartbeat', '');
+SELECT pg_logical_emit_message(false, 'debezium.heartbeat', '{"ts_ms": 123456}');
+SELECT pg_logical_emit_message(false, 'custom_tool', 'metadata');
+SQL
+
+# Make actual data changes
+psql -d ${PGCOPYDB_SOURCE_PGURI} <<'SQL'
+INSERT INTO test_table (id, name) VALUES (1, 'test1'), (2, 'test2');
+SQL
+
+# Send more messages
+psql -d ${PGCOPYDB_SOURCE_PGURI} <<'SQL'
+SELECT pg_logical_emit_message(false, 'peerdb_heartbeat', '');
+SQL
+
+# create the replication slot that captures all the changes
+coproc ( pgcopydb snapshot --follow )
+
+sleep 1
+
+# now setup the replication origin (target) and the pgcopydb.sentinel (source)
+pgcopydb stream setup
+
+# pgcopydb clone uses the environment variables
+pgcopydb clone
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
+
+# now that the copying is done, inject more SQL DML changes and messages
+psql -d ${PGCOPYDB_SOURCE_PGURI} <<'SQL'
+SELECT pg_logical_emit_message(false, 'peerdb_heartbeat', '');
+INSERT INTO test_table (id, name) VALUES (3, 'test3');
+SELECT pg_logical_emit_message(false, 'debezium.heartbeat', '{}');
+SQL
+
+# grab the current LSN, it's going to be our streaming end position
+lsn=`psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_lsn()'`
+
+# and prefetch the changes captured in our replication slot
+pgcopydb stream prefetch --resume --endpos "${lsn}"
+
+# now allow for replaying/catching-up changes
+pgcopydb stream sentinel set apply
+
+# now apply the SQL to the target database
+pgcopydb stream catchup --resume --endpos "${lsn}"
+
+# Verify data was copied
+count=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT COUNT(*) FROM test_table;")
+if [ "$count" -eq "3" ]; then
+    echo "✓ Data was copied successfully (3 rows)"
+else
+    echo "✗ Data copy failed (expected 3, got $count)"
+    exit 1
+fi
+
+# Check that JSON files do NOT contain action:"M" (filtered at source)
+SHAREDIR=/var/lib/postgres/.local/share/pgcopydb
+if grep -r '"action":"M"' ${SHAREDIR}/stream/ 2>/dev/null; then
+    echo "✗ FAILED: Found MESSAGE actions in JSON files (wal2json filter didn't work)"
+    exit 1
+else
+    echo "✓ No MESSAGE actions in JSON files (wal2json filter working)"
+fi
+
+echo "✓ CDC MESSAGE FILTERING TEST PASSED"
+
+# cleanup
+pgcopydb stream cleanup

--- a/tests/cdc-message-handling/ddl.sql
+++ b/tests/cdc-message-handling/ddl.sql
@@ -1,0 +1,12 @@
+---
+--- pgcopydb test/cdc-message-handling/ddl.sql
+---
+--- This file implements DDL for testing message filtering.
+
+DROP TABLE IF EXISTS test_table;
+CREATE TABLE test_table (
+    id SERIAL PRIMARY KEY,
+    name TEXT
+);
+
+ALTER TABLE test_table REPLICA IDENTITY FULL;


### PR DESCRIPTION
## Summary

**CDC replay filtering:**
- Fix schema and table filtering during CDC replay and catchup
- Fix filtering for PREPARE/EXECUTE statements
- Load filters from catalog in follow commands
- Filter generic messages from other replication tools (heartbeats, etc.)
- Add cdc-filtering and cdc-message-handling integration tests

**Materialized view handling:**
- Skip CDC replay for materialized views using MatViewCache
- Prevents crashes from attempting DML on materialized views

**Pipeline stability:**
- Fix prepared statement hash collision causing apply crashes (DEALLOCATE ALL at COMMIT/ROLLBACK)
- Force pipeline sync when accumulated parameter data exceeds 512 MB
- Sync pipeline mid-transaction to prevent buffer overflow on large rows

Rebased from teknogeek0/pgcopydb PRs #16, #18, #21, #34, #36, #37, #38.