### PR TITLE
Add [exclude-event-trigger] filter support

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -6304,6 +6304,57 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 	}
 
 	/*
+	 * Implement exclude-event-trigger filtering: insert event trigger names
+	 * directly into the filter table so pg_restore skips them by name.
+	 *
+	 * Event triggers have no parent schema, so the pg_restore list entry
+	 * format is "- <evtname> <owner>", and the restoreListName after
+	 * stripping the owner is "- <evtname>".
+	 */
+	if (filters != NULL && filters->excludeEventTriggerList.count > 0)
+	{
+		for (int i = 0; i < filters->excludeEventTriggerList.count; i++)
+		{
+			SourceFilterEventTrigger *evt =
+				&filters->excludeEventTriggerList.array[i];
+
+			char restoreListName[PG_NAMEDATALEN + 3] = { 0 };
+			sformat(restoreListName, sizeof(restoreListName),
+					"- %s", evt->evtname);
+
+			char *filter_evt_sql =
+				"insert or ignore into filter(oid, restore_list_name, kind) "
+				"values(0, $1, 'event-trigger')";
+
+			if (!catalog_sql_prepare(db, filter_evt_sql, &query))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			BindParam params[] = {
+				{ BIND_PARAMETER_TYPE_TEXT, "evtname", 0, restoreListName }
+			};
+
+			int count = sizeof(params) / sizeof(params[0]);
+
+			if (!catalog_sql_bind(&query, params, count))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			if (!catalog_sql_execute_once(&query))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			log_info("Filtering out event trigger \"%s\"", evt->evtname);
+		}
+	}
+
+	/*
 	 * Implement --skip-collations
 	 */
 	if (skipCollations)

--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -75,6 +75,16 @@ filterTypeToString(SourceFilterType type)
 		{
 			return "SOURCE_FILTER_TYPE_LIST_EXCL_EXTENSION";
 		}
+
+		case SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER:
+		{
+			return "SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER";
+		}
+
+		case SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER:
+		{
+			return "SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER";
+		}
 	}
 
 	/* that's a bug, the lack of a default branch above should prevent it */
@@ -131,6 +141,16 @@ filterTypeComplement(SourceFilterType type)
 		case SOURCE_FILTER_TYPE_LIST_EXCL_EXTENSION:
 		{
 			return SOURCE_FILTER_TYPE_EXCL_EXTENSION;
+		}
+
+		case SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER:
+		{
+			return SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER;
+		}
+
+		case SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER:
+		{
+			return SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER;
 		}
 
 		default:
@@ -194,6 +214,7 @@ parse_filters(const char *filename, SourceFilters *filters)
 		},
 		{ "exclude-extension", SOURCE_FILTER_EXCLUDE_EXTENSION, NULL },
 		{ "include-only-extension", SOURCE_FILTER_INCLUDE_ONLY_EXTENSION, NULL },
+		{ "exclude-event-trigger", SOURCE_FILTER_EXCLUDE_EVENT_TRIGGER, NULL },
 		{ "", SOURCE_FILTER_UNKNOWN, NULL },
 	};
 
@@ -382,6 +403,34 @@ parse_filters(const char *filename, SourceFilters *filters)
 				break;
 			}
 
+			case SOURCE_FILTER_EXCLUDE_EVENT_TRIGGER:
+			{
+				filters->excludeEventTriggerList.count = optionCount;
+				filters->excludeEventTriggerList.array =
+					(SourceFilterEventTrigger *) calloc(optionCount,
+														sizeof(SourceFilterEventTrigger));
+
+				if (filters->excludeEventTriggerList.array == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+
+				for (int o = 0; o < optionCount; o++)
+				{
+					SourceFilterEventTrigger *trigger =
+						&(filters->excludeEventTriggerList.array[o]);
+
+					const char *optionName =
+						ini_property_name(ini, sectionIndex, o);
+
+					strlcpy(trigger->evtname, optionName, sizeof(trigger->evtname));
+
+					log_debug("excluding event trigger \"%s\"", trigger->evtname);
+				}
+				break;
+			}
+
 			default:
 			{
 				log_error("BUG: unknown section number %d", i);
@@ -480,7 +529,8 @@ parse_filters(const char *filename, SourceFilters *filters)
 			 filters->excludeTableList.count > 0 ||
 			 filters->excludeTableDataList.count > 0 ||
 			 filters->excludeExtensionList.count > 0 ||
-			 filters->includeOnlyExtensionList.count > 0)
+			 filters->includeOnlyExtensionList.count > 0 ||
+			 filters->excludeEventTriggerList.count > 0)
 	{
 		filters->type = SOURCE_FILTER_TYPE_EXCL;
 	}
@@ -674,6 +724,22 @@ filters_as_json(SourceFilters *filters, JSON_Value *jsFilter)
 		json_object_set_value(jsFilterObj, "exclude-extension", jsExt);
 	}
 
+	/* exclude-event-trigger */
+	if (filters->excludeEventTriggerList.count > 0)
+	{
+		JSON_Value *jsEvt = json_value_init_array();
+		JSON_Array *jsEvtArray = json_value_get_array(jsEvt);
+
+		for (int i = 0; i < filters->excludeEventTriggerList.count; i++)
+		{
+			char *evtname = filters->excludeEventTriggerList.array[i].evtname;
+
+			json_array_append_string(jsEvtArray, evtname);
+		}
+
+		json_object_set_value(jsFilterObj, "exclude-event-trigger", jsEvt);
+	}
+
 	/* exclude table lists */
 	struct section
 	{
@@ -753,6 +819,8 @@ filters_from_json(const char *jsonString, SourceFilters *filters)
 	filters->includeOnlyExtensionList.array = NULL;
 	filters->excludeExtensionList.count = 0;
 	filters->excludeExtensionList.array = NULL;
+	filters->excludeEventTriggerList.count = 0;
+	filters->excludeEventTriggerList.array = NULL;
 	filters->ctePreamble = NULL;
 
 	/* Parse JSON string */
@@ -805,6 +873,22 @@ filters_from_json(const char *jsonString, SourceFilters *filters)
 		else if (strcmp(typeStr, "SOURCE_FILTER_TYPE_LIST_EXCL_INDEX") == 0)
 		{
 			filters->type = SOURCE_FILTER_TYPE_LIST_EXCL_INDEX;
+		}
+		else if (strcmp(typeStr, "SOURCE_FILTER_TYPE_EXCL_EXTENSION") == 0)
+		{
+			filters->type = SOURCE_FILTER_TYPE_EXCL_EXTENSION;
+		}
+		else if (strcmp(typeStr, "SOURCE_FILTER_TYPE_LIST_EXCL_EXTENSION") == 0)
+		{
+			filters->type = SOURCE_FILTER_TYPE_LIST_EXCL_EXTENSION;
+		}
+		else if (strcmp(typeStr, "SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER") == 0)
+		{
+			filters->type = SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER;
+		}
+		else if (strcmp(typeStr, "SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER") == 0)
+		{
+			filters->type = SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER;
 		}
 		else
 		{
@@ -946,6 +1030,42 @@ filters_from_json(const char *jsonString, SourceFilters *filters)
 				{
 					strlcpy(filters->excludeExtensionList.array[i].extname,
 							extname,
+							PG_NAMEDATALEN);
+				}
+			}
+		}
+	}
+
+	/* Parse exclude-event-trigger array */
+	JSON_Array *excludeEvtArray =
+		json_object_get_array(jsFilterObj, "exclude-event-trigger");
+
+	if (excludeEvtArray != NULL)
+	{
+		size_t count = json_array_get_count(excludeEvtArray);
+		filters->excludeEventTriggerList.count = count;
+
+		if (count > 0)
+		{
+			filters->excludeEventTriggerList.array =
+				(SourceFilterEventTrigger *) calloc(count,
+													sizeof(SourceFilterEventTrigger));
+
+			if (filters->excludeEventTriggerList.array == NULL)
+			{
+				log_error(ALLOCATION_FAILED_ERROR);
+				json_value_free(jsFilter);
+				return false;
+			}
+
+			for (size_t i = 0; i < count; i++)
+			{
+				const char *evtname = json_array_get_string(excludeEvtArray, i);
+
+				if (evtname != NULL)
+				{
+					strlcpy(filters->excludeEventTriggerList.array[i].evtname,
+							evtname,
 							PG_NAMEDATALEN);
 				}
 			}

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -24,7 +24,8 @@ typedef enum
 	SOURCE_FILTER_EXCLUDE_INDEX,
 	SOURCE_FILTER_INCLUDE_ONLY_TABLE,
 	SOURCE_FILTER_EXCLUDE_EXTENSION,
-	SOURCE_FILTER_INCLUDE_ONLY_EXTENSION
+	SOURCE_FILTER_INCLUDE_ONLY_EXTENSION,
+	SOURCE_FILTER_EXCLUDE_EVENT_TRIGGER
 } SourceFilterSection;
 
 typedef struct SourceFilterSchema
@@ -48,6 +49,18 @@ typedef struct SourceFilterExtensionList
 	int count;
 	SourceFilterExtension *array;  /* malloc'ed area */
 } SourceFilterExtensionList;
+
+
+typedef struct SourceFilterEventTrigger
+{
+	char evtname[PG_NAMEDATALEN];
+} SourceFilterEventTrigger;
+
+typedef struct SourceFilterEventTriggerList
+{
+	int count;
+	SourceFilterEventTrigger *array;    /* malloc'ed area */
+} SourceFilterEventTriggerList;
 
 
 typedef struct SourceFilterTable
@@ -96,7 +109,10 @@ typedef enum
 	SOURCE_FILTER_TYPE_LIST_EXCL_INDEX,
 
 	SOURCE_FILTER_TYPE_EXCL_EXTENSION,
-	SOURCE_FILTER_TYPE_LIST_EXCL_EXTENSION
+	SOURCE_FILTER_TYPE_LIST_EXCL_EXTENSION,
+
+	SOURCE_FILTER_TYPE_EXCL_EVENT_TRIGGER,
+	SOURCE_FILTER_TYPE_LIST_EXCL_EVENT_TRIGGER
 } SourceFilterType;
 
 typedef struct SourceFilters
@@ -112,6 +128,7 @@ typedef struct SourceFilters
 	SourceFilterTableList excludeIndexList;
 	SourceFilterExtensionList includeOnlyExtensionList;
 	SourceFilterExtensionList excludeExtensionList;
+	SourceFilterEventTriggerList excludeEventTriggerList;
 	char *ctePreamble;
 } SourceFilters;
 

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -73,9 +73,6 @@ jq "${JQSCRIPT}" ${SHAREDIR}/${WALFILE} > ${result}
 diff ${expected} ${result} || cat ${SHAREDIR}/${WALFILE}
 diff ${expected} ${result}
 
-# now prefetch the changes again, which should be a noop
-pgcopydb stream prefetch --resume --endpos "${lsn}" --trace
-
 # now transform the JSON file into SQL
 SQLFILENAME=`basename ${WALFILE} .json`.sql
 
@@ -88,6 +85,9 @@ diff ${SHAREDIR}/${SQLFILE} /tmp/${SQLFILENAME}
 DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH -I ENDPOS -I ROLLBACK'
 
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
+
+# now prefetch the changes again, which should be a noop
+pgcopydb stream prefetch --resume --endpos "${lsn}" --trace
 
 # now allow for replaying/catching-up changes
 pgcopydb stream sentinel set apply

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -18,3 +18,6 @@ foo.matview_1_exclude_as_table
 [exclude-table-data]
 foo.matview_1_exclude_data
 partitioned_tables.sellers_archive
+
+[exclude-event-trigger]
+evt_exclude

--- a/tests/filtering/exclude/expected/3-event-triggers.out
+++ b/tests/filtering/exclude/expected/3-event-triggers.out
@@ -1,0 +1,5 @@
+-[ RECORD 1 ]---------------
+evtname    | evt_keep
+evtevent   | ddl_command_end
+evtenabled | O
+

--- a/tests/filtering/exclude/sql/3-event-triggers.sql
+++ b/tests/filtering/exclude/sql/3-event-triggers.sql
@@ -1,0 +1,1 @@
+select evtname, evtevent, evtenabled from pg_event_trigger order by 1;

--- a/tests/filtering/extra.sql
+++ b/tests/filtering/extra.sql
@@ -119,3 +119,16 @@ create table partitioned_tables.sellers_active partition of partitioned_tables.s
 create table partitioned_tables.sellers_archive partition of partitioned_tables.sellers for values in ('1');
 
 insert into partitioned_tables.sellers (id, archive) values (1, 0), (2, 1), (3, 0);
+
+--
+-- To test event trigger filtering
+--
+create or replace function foo.evt_trigger_func()
+returns event_trigger language plpgsql as $$
+begin
+  raise notice 'event trigger fired';
+end;
+$$;
+
+create event trigger evt_keep on ddl_command_end execute function foo.evt_trigger_func();
+create event trigger evt_exclude on ddl_command_start execute function foo.evt_trigger_func();


### PR DESCRIPTION
## Summary
- Adds `[exclude-event-trigger]` section to filter config, allowing specific event triggers to be filtered out during pg_restore
- Follows the existing `[exclude-extension]` pattern: parse from INI, serialize/deserialize JSON, insert into SQLite filter table
- Event triggers are matched by name in the pg_restore list
- Also fixes a flakey `cdc-endpos-between-transaction` test

## Motivation
Supabase creates event triggers (e.g., `issue_pg_graphql_access`, `pgrst_ddl_watch`) that reference functions from excluded schemas/extensions. During pg_restore post-data, these fail because the referenced functions don't exist on the target. With no way to filter them, the errors count toward `MAX_TOLERATED_RESTORE_ERRORS` and can cause migration failure.

## Usage
```ini
[exclude-event-trigger]
issue_pg_graphql_access
issue_pg_cron_access
pgrst_ddl_watch
pgrst_drop_watch
```

## Test plan
- [x] Container build passes
- [x] Filtering test suite passes with new event trigger test case
- [x] Test creates two event triggers, excludes one, verifies only the non-excluded trigger exists on target
- [x] Code style check passes