### PR TITLE
Pass exclude-table filters to pg_dump

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -8468,13 +8468,18 @@ catalog_s_depend_fetch(SQLiteQuery *query)
 	/* cleanup the memory area before re-use */
 	bzero(dep, sizeof(SourceDepend));
 
-	strlcpy(dep->nspname,
-			(char *) sqlite3_column_text(query->ppStmt, 0),
-			sizeof(dep->nspname));
+	const char *nspname = (const char *) sqlite3_column_text(query->ppStmt, 0);
+	const char *relname = (const char *) sqlite3_column_text(query->ppStmt, 1);
 
-	strlcpy(dep->relname,
-			(char *) sqlite3_column_text(query->ppStmt, 1),
-			sizeof(dep->relname));
+	if (nspname != NULL)
+	{
+		strlcpy(dep->nspname, nspname, sizeof(dep->nspname));
+	}
+
+	if (relname != NULL)
+	{
+		strlcpy(dep->relname, relname, sizeof(dep->relname));
+	}
 
 	dep->refclassid = sqlite3_column_int64(query->ppStmt, 2);
 	dep->refobjid = sqlite3_column_int64(query->ppStmt, 3);
@@ -8484,7 +8489,7 @@ catalog_s_depend_fetch(SQLiteQuery *query)
 	char *deptype = (char *) sqlite3_column_text(query->ppStmt, 6);
 
 	/* we have a single char deptype */
-	dep->deptype = deptype[0];
+	dep->deptype = deptype != NULL ? deptype[0] : 'n';
 
 	if (sqlite3_column_type(query->ppStmt, 7) != SQLITE_NULL)
 	{

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -447,6 +447,29 @@ pg_dump_db(PostgresPaths *pgPaths,
 		args[argsIndex++] = nspname;
 	}
 
+	/* apply [exclude-table] filtering */
+	char excludeTableNames[PG_CMD_MAX_ARG][PG_NAMEDATALEN_FQ];
+
+	for (int i = 0; i < filters->excludeTableList.count; i++)
+	{
+		char *nspname = filters->excludeTableList.array[i].nspname;
+		char *relname = filters->excludeTableList.array[i].relname;
+
+		if (PG_CMD_MAX_ARG < (argsIndex + 2))
+		{
+			log_error("Failed to call pg_dump, too many exclude-table "
+					  "entries: argsIndex %d > %d",
+					  argsIndex + 2, PG_CMD_MAX_ARG);
+			return false;
+		}
+
+		sformat(excludeTableNames[i], PG_NAMEDATALEN_FQ, "%s.%s",
+				nspname, relname);
+
+		args[argsIndex++] = "--exclude-table";
+		args[argsIndex++] = excludeTableNames[i];
+	}
+
 	args[argsIndex++] = "--file";
 	args[argsIndex++] = (char *) filename;
 	args[argsIndex++] = (char *) connStrings->safeSourcePGURI.pguri;

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3300,7 +3300,6 @@ schema_list_pg_depend(PGSQL *pgsql,
 		}
 
 		log_info("Extension dependencies fetched successfully");
-		return true;
 	}
 
 	log_debug("listSourceDependSQL[%s]", filterTypeToString(filters->type));
@@ -3337,6 +3336,365 @@ schema_list_pg_depend(PGSQL *pgsql,
 	{
 		log_error("Failed to list table dependencies");
 		return false;
+	}
+
+	/*
+	 * Cross-schema dependency filtering: detect objects in non-excluded
+	 * schemas that reference objects in excluded schemas. These must also
+	 * be filtered out to avoid pg_restore failures.
+	 *
+	 * These queries reference the filter_exclude_schema temp table created
+	 * by prepareFilters(). On read-only standbys, temp tables cannot be
+	 * created, so we skip these queries for now.
+	 */
+	if (filters->isReadOnly)
+	{
+		log_info("Skipping cross-schema dependency queries on read-only source");
+		return true;
+	}
+
+	/* Query 1: FK constraints referencing tables in excluded schemas */
+	if (filters->excludeSchemaList.count > 0)
+	{
+		char *fk_depend_sql =
+			"SELECT cn.nspname, cl.relname, "
+			"       'pg_class'::regclass::oid AS refclassid, "
+			"       confrelid AS refobjid, "
+			"       'pg_constraint'::regclass::oid AS classid, "
+			"       con.oid AS objid, "
+			"       'n' AS deptype, "
+			"       'constraint' AS type, "
+			"       cn.nspname || '.' || cl.relname || '.' || con.conname "
+			"           AS identity "
+			"  FROM pg_catalog.pg_constraint con "
+			"  JOIN pg_catalog.pg_class cl ON con.conrelid = cl.oid "
+			"  JOIN pg_catalog.pg_namespace cn ON cl.relnamespace = cn.oid "
+			"  JOIN pg_catalog.pg_class rcl ON con.confrelid = rcl.oid "
+			"  JOIN pg_catalog.pg_namespace rn ON rcl.relnamespace = rn.oid "
+			"  JOIN filter_exclude_schema es ON rn.nspname = es.nspname "
+			" WHERE con.contype = 'f' "
+			"   AND cn.nspname !~ '^pg_' "
+			"   AND cn.nspname <> 'information_schema' "
+			"   AND NOT EXISTS ("
+			"       SELECT 1 FROM filter_exclude_schema xs "
+			"        WHERE xs.nspname = cn.nspname)";
+
+		SourceDependArrayContext fkContext = { { 0 }, catalog, false };
+
+		log_info("Fetching FK constraints referencing excluded schemas");
+
+		if (!pgsql_execute_with_params(pgsql, fk_depend_sql,
+									   0, NULL, NULL,
+									   &fkContext, &getDependArray))
+		{
+			log_error("Failed to list FK cross-schema dependencies");
+			return false;
+		}
+
+		if (!fkContext.parsedOk)
+		{
+			log_error("Failed to parse FK cross-schema dependencies");
+			return false;
+		}
+	}
+
+	/* Query 2: Views that depend on objects in excluded schemas */
+	if (filters->excludeSchemaList.count > 0)
+	{
+		char *view_depend_sql =
+			"SELECT vn.nspname, vc.relname, "
+			"       d.refclassid, d.refobjid, "
+			"       'pg_class'::regclass::oid AS classid, "
+			"       vc.oid AS objid, "
+			"       d.deptype, "
+			"       'view' AS type, "
+			"       vn.nspname || '.' || vc.relname AS identity "
+			"  FROM pg_catalog.pg_depend d "
+			"  JOIN pg_catalog.pg_rewrite rw "
+			"    ON d.classid = 'pg_rewrite'::regclass "
+			"   AND d.objid = rw.oid "
+			"  JOIN pg_catalog.pg_class vc ON rw.ev_class = vc.oid "
+			"  JOIN pg_catalog.pg_namespace vn "
+			"    ON vc.relnamespace = vn.oid "
+			"  JOIN pg_catalog.pg_class rc "
+			"    ON d.refclassid = 'pg_class'::regclass "
+			"   AND d.refobjid = rc.oid "
+			"  JOIN pg_catalog.pg_namespace rn "
+			"    ON rc.relnamespace = rn.oid "
+			"  JOIN filter_exclude_schema es "
+			"    ON rn.nspname = es.nspname "
+			" WHERE vc.relkind IN ('v', 'm') "
+			"   AND vn.nspname !~ '^pg_' "
+			"   AND vn.nspname <> 'information_schema' "
+			"   AND NOT EXISTS ("
+			"       SELECT 1 FROM filter_exclude_schema xs "
+			"        WHERE xs.nspname = vn.nspname) "
+			" GROUP BY vn.nspname, vc.relname, d.refclassid, "
+			"          d.refobjid, vc.oid, d.deptype";
+
+		SourceDependArrayContext viewContext = { { 0 }, catalog, false };
+
+		log_info("Fetching views depending on excluded schemas");
+
+		if (!pgsql_execute_with_params(pgsql, view_depend_sql,
+									   0, NULL, NULL,
+									   &viewContext, &getDependArray))
+		{
+			log_error("Failed to list view cross-schema dependencies");
+			return false;
+		}
+
+		if (!viewContext.parsedOk)
+		{
+			log_error("Failed to parse view cross-schema dependencies");
+			return false;
+		}
+	}
+
+	/* Query 3: RLS policies that depend on excluded schemas */
+	if (filters->excludeSchemaList.count > 0)
+	{
+		char *policy_depend_sql =
+
+			/*
+			 * Find policies via pg_depend that reference objects
+			 * (functions, tables) in excluded schemas. Also use
+			 * text-based scanning of policy expressions as a
+			 * fallback for cases pg_depend doesn't track.
+			 */
+			"SELECT DISTINCT pn.nspname, pc.relname, "
+			"       d.refclassid, d.refobjid, "
+			"       'pg_policy'::regclass::oid AS classid, "
+			"       pol.oid AS objid, "
+			"       d.deptype, "
+			"       'policy' AS type, "
+			"       pn.nspname || '.' || pc.relname || '.' "
+			"           || pol.polname AS identity "
+			"  FROM pg_catalog.pg_policy pol "
+			"  JOIN pg_catalog.pg_class pc "
+			"    ON pol.polrelid = pc.oid "
+			"  JOIN pg_catalog.pg_namespace pn "
+			"    ON pc.relnamespace = pn.oid "
+			"  JOIN pg_catalog.pg_depend d "
+			"    ON d.classid = 'pg_policy'::regclass "
+			"   AND d.objid = pol.oid "
+			" WHERE pn.nspname !~ '^pg_' "
+			"   AND pn.nspname <> 'information_schema' "
+			"   AND NOT EXISTS ("
+			"       SELECT 1 FROM filter_exclude_schema xs "
+			"        WHERE xs.nspname = pn.nspname) "
+			"   AND ("
+			"     (d.refclassid = 'pg_proc'::regclass AND EXISTS ("
+			"       SELECT 1 FROM pg_catalog.pg_proc rp "
+			"       JOIN pg_catalog.pg_namespace rn "
+			"         ON rp.pronamespace = rn.oid "
+			"       JOIN filter_exclude_schema es "
+			"         ON rn.nspname = es.nspname "
+			"       WHERE rp.oid = d.refobjid)) "
+			"     OR "
+			"     (d.refclassid = 'pg_class'::regclass AND EXISTS ("
+			"       SELECT 1 FROM pg_catalog.pg_class rc "
+			"       JOIN pg_catalog.pg_namespace rn "
+			"         ON rc.relnamespace = rn.oid "
+			"       JOIN filter_exclude_schema es "
+			"         ON rn.nspname = es.nspname "
+			"       WHERE rc.oid = d.refobjid)) "
+			"   )";
+
+		SourceDependArrayContext polContext = { { 0 }, catalog, false };
+
+		log_info("Fetching RLS policies depending on excluded schemas");
+
+		if (!pgsql_execute_with_params(pgsql, policy_depend_sql,
+									   0, NULL, NULL,
+									   &polContext, &getDependArray))
+		{
+			log_error("Failed to list policy cross-schema dependencies");
+			return false;
+		}
+
+		if (!polContext.parsedOk)
+		{
+			log_error("Failed to parse policy cross-schema dependencies");
+			return false;
+		}
+	}
+
+	/* Query 5: Functions depending on excluded schemas */
+	if (filters->excludeSchemaList.count > 0)
+	{
+		char *func_depend_sql =
+			"SELECT fn.nspname, '' AS relname, "
+			"       d.refclassid, d.refobjid, "
+			"       'pg_proc'::regclass::oid AS classid, "
+			"       p.oid AS objid, "
+			"       d.deptype, "
+			"       'function' AS type, "
+			"       fn.nspname || '.' || p.proname AS identity "
+			"  FROM pg_catalog.pg_proc p "
+			"  JOIN pg_catalog.pg_namespace fn "
+			"    ON p.pronamespace = fn.oid "
+			"  JOIN pg_catalog.pg_depend d "
+			"    ON d.classid = 'pg_proc'::regclass "
+			"   AND d.objid = p.oid "
+			" WHERE fn.nspname !~ '^pg_' "
+			"   AND fn.nspname <> 'information_schema' "
+			"   AND NOT EXISTS ("
+			"       SELECT 1 FROM filter_exclude_schema xs "
+			"        WHERE xs.nspname = fn.nspname) "
+			"   AND NOT EXISTS ("
+			"       SELECT 1 FROM pg_depend ed "
+			"        WHERE ed.objid = p.oid "
+			"          AND ed.deptype = 'e') "
+			"   AND ("
+			"     (d.refclassid = 'pg_proc'::regclass AND EXISTS ("
+			"       SELECT 1 FROM pg_catalog.pg_proc rp "
+			"       JOIN pg_catalog.pg_namespace rn "
+			"         ON rp.pronamespace = rn.oid "
+			"       JOIN filter_exclude_schema es "
+			"         ON rn.nspname = es.nspname "
+			"       WHERE rp.oid = d.refobjid)) "
+			"     OR "
+			"     (d.refclassid = 'pg_class'::regclass AND EXISTS ("
+			"       SELECT 1 FROM pg_catalog.pg_class rc "
+			"       JOIN pg_catalog.pg_namespace rn "
+			"         ON rc.relnamespace = rn.oid "
+			"       JOIN filter_exclude_schema es "
+			"         ON rn.nspname = es.nspname "
+			"       WHERE rc.oid = d.refobjid)) "
+			"     OR "
+			"     (d.refclassid = 'pg_namespace'::regclass AND EXISTS ("
+			"       SELECT 1 FROM filter_exclude_schema es "
+			"       JOIN pg_catalog.pg_namespace rn "
+			"         ON rn.nspname = es.nspname "
+			"       WHERE rn.oid = d.refobjid)) "
+			"   ) "
+			" GROUP BY fn.nspname, p.oid, p.proname, "
+			"          d.refclassid, d.refobjid, d.deptype";
+
+		SourceDependArrayContext funcContext = { { 0 }, catalog, false };
+
+		log_info("Fetching functions depending on excluded schemas");
+
+		if (!pgsql_execute_with_params(pgsql, func_depend_sql,
+									   0, NULL, NULL,
+									   &funcContext, &getDependArray))
+		{
+			log_error("Failed to list function cross-schema dependencies");
+			return false;
+		}
+
+		if (!funcContext.parsedOk)
+		{
+			log_error("Failed to parse function cross-schema dependencies");
+			return false;
+		}
+	}
+
+	/* Query 4: Event trigger backing functions */
+	if (filters->excludeEventTriggerList.count > 0)
+	{
+		/*
+		 * Build a VALUES clause from the event trigger names since
+		 * there is no temp table for event triggers in prepareFilters.
+		 */
+		PQExpBuffer buf = createPQExpBuffer();
+
+		appendPQExpBufferStr(buf,
+							 "SELECT pn.nspname, '' AS relname, "
+							 "       'pg_event_trigger'::regclass::oid AS refclassid, "
+							 "       evt.oid AS refobjid, "
+							 "       'pg_proc'::regclass::oid AS classid, "
+							 "       p.oid AS objid, "
+							 "       'n' AS deptype, "
+							 "       'function' AS type, "
+							 "       pn.nspname || '.' || p.proname AS identity "
+							 "  FROM pg_catalog.pg_event_trigger evt "
+							 "  JOIN pg_catalog.pg_proc p ON evt.evtfoid = p.oid "
+							 "  JOIN pg_catalog.pg_namespace pn "
+							 "    ON p.pronamespace = pn.oid "
+							 " WHERE evt.evtname IN (");
+
+		for (int i = 0; i < filters->excludeEventTriggerList.count; i++)
+		{
+			if (i > 0)
+			{
+				appendPQExpBufferStr(buf, ", ");
+			}
+
+			char *name =
+				filters->excludeEventTriggerList.array[i].evtname;
+
+			char *escaped =
+				PQescapeLiteral(pgsql->connection,
+								name, strlen(name));
+
+			if (escaped == NULL)
+			{
+				log_error("Failed to escape event trigger name: %s",
+						  PQerrorMessage(pgsql->connection));
+				destroyPQExpBuffer(buf);
+				return false;
+			}
+
+			appendPQExpBufferStr(buf, escaped);
+			PQfreemem(escaped);
+		}
+
+		appendPQExpBufferStr(buf, ")"
+								  " AND NOT EXISTS ("
+								  "   SELECT 1 FROM pg_catalog.pg_event_trigger other "
+								  "    WHERE other.evtfoid = p.oid "
+								  "      AND other.evtname NOT IN (");
+
+		for (int i = 0; i < filters->excludeEventTriggerList.count; i++)
+		{
+			if (i > 0)
+			{
+				appendPQExpBufferStr(buf, ", ");
+			}
+
+			char *name2 =
+				filters->excludeEventTriggerList.array[i].evtname;
+
+			char *escaped2 =
+				PQescapeLiteral(pgsql->connection,
+								name2, strlen(name2));
+
+			if (escaped2 == NULL)
+			{
+				log_error("Failed to escape event trigger name: %s",
+						  PQerrorMessage(pgsql->connection));
+				destroyPQExpBuffer(buf);
+				return false;
+			}
+
+			appendPQExpBufferStr(buf, escaped2);
+			PQfreemem(escaped2);
+		}
+
+		appendPQExpBufferStr(buf, "))");
+
+		SourceDependArrayContext evtContext = { { 0 }, catalog, false };
+
+		log_info("Fetching event trigger backing functions");
+
+		if (!pgsql_execute_with_params(pgsql, buf->data,
+									   0, NULL, NULL,
+									   &evtContext, &getDependArray))
+		{
+			log_error("Failed to list event trigger function dependencies");
+			destroyPQExpBuffer(buf);
+			return false;
+		}
+
+		destroyPQExpBuffer(buf);
+
+		if (!evtContext.parsedOk)
+		{
+			log_error("Failed to parse event trigger function dependencies");
+			return false;
+		}
 	}
 
 	return true;

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -2,6 +2,7 @@
 public
 bar
 schema_name_20_chars
+excluded_test
 
 [exclude-table]
 ; public.actor

--- a/tests/filtering/exclude/expected/4-cross-schema-deps.out
+++ b/tests/filtering/exclude/expected/4-cross-schema-deps.out
@@ -1,0 +1,15 @@
+-[ RECORD 1 ]------------+--
+tbl_with_cross_fk_exists | 1
+
+-[ RECORD 1 ]--+--
+cross_fk_count | 0
+
+-[ RECORD 1 ]----+--
+cross_view_count | 0
+
+-[ RECORD 1 ]-------------+--
+tbl_with_cross_rls_exists | 1
+
+-[ RECORD 1 ]------+--
+cross_policy_count | 0
+

--- a/tests/filtering/exclude/sql/4-cross-schema-deps.sql
+++ b/tests/filtering/exclude/sql/4-cross-schema-deps.sql
@@ -1,0 +1,30 @@
+-- verify the tables themselves exist (they're in foo, not excluded)
+select count(*) as tbl_with_cross_fk_exists
+  from pg_tables
+ where schemaname = 'foo' and tablename = 'tbl_with_cross_fk';
+
+-- FK constraint referencing excluded schema should NOT exist
+select count(*) as cross_fk_count
+  from pg_constraint c
+  join pg_class cl on c.conrelid = cl.oid
+  join pg_namespace n on cl.relnamespace = n.oid
+ where c.contype = 'f'
+   and n.nspname = 'foo'
+   and cl.relname = 'tbl_with_cross_fk';
+
+-- view referencing excluded schema should NOT exist
+select count(*) as cross_view_count
+  from pg_views
+ where schemaname = 'foo' and viewname = 'cross_schema_view';
+
+-- RLS table should exist
+select count(*) as tbl_with_cross_rls_exists
+  from pg_tables
+ where schemaname = 'foo' and tablename = 'tbl_with_cross_rls';
+
+-- RLS policy referencing excluded schema should NOT exist
+select count(*) as cross_policy_count
+  from pg_policy pol
+  join pg_class c on pol.polrelid = c.oid
+  join pg_namespace n on c.relnamespace = n.oid
+ where n.nspname = 'foo' and pol.polname = 'cross_schema_policy';

--- a/tests/filtering/extra.sql
+++ b/tests/filtering/extra.sql
@@ -132,3 +132,44 @@ $$;
 
 create event trigger evt_keep on ddl_command_end execute function foo.evt_trigger_func();
 create event trigger evt_exclude on ddl_command_start execute function foo.evt_trigger_func();
+
+--
+-- To test cross-schema dependency filtering
+-- Objects in non-excluded schemas that reference excluded schemas
+-- should have their cross-schema dependencies filtered out
+--
+create schema excluded_test;
+
+create table excluded_test.users (
+    id bigserial primary key,
+    email text
+);
+
+insert into excluded_test.users (id, email) values (1, 'test@example.com');
+
+create or replace function excluded_test.get_uid()
+returns bigint language sql stable as $$ select 1::bigint; $$;
+
+-- Table in foo schema with FK referencing excluded schema
+create table foo.tbl_with_cross_fk (
+    id bigserial primary key,
+    user_id bigint references excluded_test.users(id)
+);
+
+insert into foo.tbl_with_cross_fk (id, user_id) values (1, 1);
+
+-- View in foo schema referencing excluded schema
+create view foo.cross_schema_view as select * from excluded_test.users;
+
+-- Table in foo schema with RLS policy referencing excluded schema function
+create table foo.tbl_with_cross_rls (
+    id bigserial primary key,
+    owner_id bigint
+);
+
+insert into foo.tbl_with_cross_rls (id, owner_id) values (1, 1);
+
+alter table foo.tbl_with_cross_rls enable row level security;
+
+create policy cross_schema_policy on foo.tbl_with_cross_rls
+    using (owner_id = excluded_test.get_uid());


### PR DESCRIPTION
## Summary
- Passes `--exclude-table` flags to `pg_dump` so that tables in the `[exclude-table]` filter are omitted from the schema dump entirely
- Previously, exclude-table filters were only applied during the COPY phase, meaning excluded tables still appeared in the dumped schema

## Test plan
- [x] Build in container: `PGVERSION=16 make build`
- [x] Run filtering test: `PGVERSION=16 make tests/filtering`
- [x] Verify excluded tables do not appear in pg_dump output