### PR TITLE
Update actions/checkout to v6 for Node.js 24

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # all history for all branches and tags
 

--- a/.github/workflows/run-tests-tiered.yml
+++ b/.github/workflows/run-tests-tiered.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     container: citus/stylechecker:no-py
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v6
       name: Checkout code
 
     - name: Set safe directory for git
@@ -40,7 +40,7 @@ jobs:
     name: Check for banned APIs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Check for banned APIs
       run: sh ./ci/banned.h.sh
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build docs
         uses: ammaraskar/sphinx-action@master
@@ -88,7 +88,7 @@ jobs:
           - unit
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -155,7 +155,7 @@ jobs:
           - endpos-in-multi-wal-txn
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6 across all workflow files
- Resolves Node.js 20 deprecation warnings in CI
- Node.js 20 runners will be forced to Node.js 24 starting June 2, 2026