### PR TITLE
Fix early snapshot release and defer indexes with --follow

### DIFF
--- a/.github/workflows/run-tests-tiered.yml
+++ b/.github/workflows/run-tests-tiered.yml
@@ -153,6 +153,8 @@ jobs:
           - follow-9.6
           - follow-data-only
           - endpos-in-multi-wal-txn
+          - blob-snapshot-release
+          - follow-defer-indexes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/src/bin/pgcopydb/blobs.c
+++ b/src/bin/pgcopydb/blobs.c
@@ -174,6 +174,17 @@ copydb_has_large_objects(CopyDataSpec *specs, bool *hasLargeObjects)
 
 	*hasLargeObjects = context.boolVal;
 
+	/*
+	 * Close the REPEATABLE READ snapshot connection now that the query is
+	 * done.  Leaving it open would pin backend_xmin on the source for the
+	 * lifetime of the clone subprocess (through index building and
+	 * post-data restore), preventing VACUUM from advancing.
+	 */
+	if (!copydb_close_snapshot(specs))
+	{
+		log_warn("Failed to close snapshot after large object check");
+	}
+
 	return true;
 }
 

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -409,6 +409,64 @@ clone_and_follow(CopyDataSpec *copySpecs)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
+	/*
+	 * When --defer-indexes with --follow, PID B exited after COPY without
+	 * building indexes. Run STEP 10 here so index workers are direct
+	 * children of this process — their semaphores survive CDC failures.
+	 *
+	 * We must enable CDC apply (sentinel_update_apply) BEFORE calling
+	 * copydb_target_finalize_schema, because that function internally calls
+	 * copydb_wait_for_subprocesses which uses waitpid(-1) — waiting for ALL
+	 * children including the follow process (PID C). PID C won't exit until
+	 * CDC apply finishes, so sentinel apply must be enabled first to avoid
+	 * deadlock. This means CDC applies DML while indexes are being built,
+	 * which is safe: primary keys exist from pre-data restore.
+	 *
+	 * Because copydb_wait_for_subprocesses reaps PID C, we set followPID to
+	 * -1 afterward to skip the redundant follow wait below.
+	 */
+	if (copySpecs->deferIndexes)
+	{
+		log_info("STEP 10: restore the post-data section to the target database");
+
+		/* Open the catalog in this process (PID B closed its copy on exit) */
+		if (!catalog_open_from_specs(copySpecs))
+		{
+			log_error("Failed to open catalogs for deferred index creation");
+			(void) copydb_fatal_exit();
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		/* Enable CDC apply before building indexes (see comment above) */
+		DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
+
+		log_info("Updating the pgcopydb.sentinel to enable applying changes");
+
+		if (!sentinel_update_apply(sourceDB, true))
+		{
+			(void) copydb_fatal_exit();
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		if (!copydb_target_finalize_schema(copySpecs))
+		{
+			log_error("Failed to finalize schema, see above for details");
+			(void) copydb_fatal_exit();
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		if (!catalog_close_from_specs(copySpecs))
+		{
+			log_error("Failed to close catalogs after deferred index creation");
+		}
+
+		/*
+		 * copydb_wait_for_subprocesses (inside copydb_target_finalize_schema)
+		 * already reaped PID C via waitpid(-1). Skip the follow wait below.
+		 */
+		followPID = -1;
+	}
+
 	/* now wait until the follow process is finished, if it's been started */
 	if (followPID != -1)
 	{
@@ -703,28 +761,41 @@ cloneDB(CopyDataSpec *copySpecs)
 		/* Non-fatal: parent falls back to closing snapshot after clone exits */
 	}
 
-	log_info("STEP 10: restore the post-data section to the target database");
-
-	if (!copydb_target_finalize_schema(copySpecs))
-	{
-		log_error("Failed to finalize schema on the target database, "
-				  "see above for details");
-		(void) summary_print_failure_report(copySpecs);
-		return false;
-	}
-
 	/*
-	 * When --follow has been used, now is the time to allow for the catchup
-	 * process to start applying the prefetched changes.
+	 * When --defer-indexes AND --follow, STEP 10 is handled by the
+	 * parent process (PID A) so that index workers are direct children of
+	 * PID A and their semaphores survive CDC failures.
 	 */
-	if (copySpecs->follow)
+	if (copySpecs->follow && copySpecs->deferIndexes)
 	{
-		log_info("Updating the pgcopydb.sentinel to enable applying changes");
+		log_info("STEP 10: deferred to parent process (clone --follow)");
+	}
+	else
+	{
+		log_info("STEP 10: restore the post-data section to the target database");
 
-		if (!sentinel_update_apply(sourceDB, true))
+		if (!copydb_target_finalize_schema(copySpecs))
 		{
-			/* errors have already been logged */
+			log_error("Failed to finalize schema on the target database, "
+					  "see above for details");
+			(void) summary_print_failure_report(copySpecs);
 			return false;
+		}
+
+		/*
+		 * When --follow has been used, now is the time to allow for the
+		 * catchup process to start applying the prefetched changes.
+		 */
+		if (copySpecs->follow)
+		{
+			log_info("Updating the pgcopydb.sentinel to enable applying "
+					 "changes");
+
+			if (!sentinel_update_apply(sourceDB, true))
+			{
+				/* errors have already been logged */
+				return false;
+			}
 		}
 	}
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -555,6 +555,40 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 		return false;
 	}
 
+	/*
+	 * When --defer-indexes --follow was used, STEP 6 was skipped in the
+	 * clone subprocess. Build indexes now using pgcopydb's parallel workers
+	 * (CREATE INDEX with ShareLock, then ALTER TABLE ADD CONSTRAINT USING
+	 * INDEX with brief AccessExclusiveLock), instead of letting pg_restore
+	 * do it with a single ALTER TABLE that holds AccessExclusiveLock for
+	 * hours.
+	 *
+	 * Without --follow, --defer-indexes only reorders index creation within
+	 * the COPY supervisor (STEP 6 still runs), so indexes already exist.
+	 *
+	 * Workers record completions in the summary catalog, so the restore
+	 * list hook will comment out these entries automatically.
+	 */
+	if (specs->deferIndexes && specs->follow)
+	{
+		log_info("Creating deferred indexes and constraints using "
+				 "%d parallel workers", specs->indexJobs);
+
+		bool savedSkipVacuum = specs->skipVacuum;
+		specs->skipVacuum = true;
+
+		bool ok = copydb_copy_all_indexes(specs);
+
+		specs->skipVacuum = savedSkipVacuum;
+
+		if (!ok)
+		{
+			log_error("Failed to create deferred indexes, "
+					  "see above for details");
+			return false;
+		}
+	}
+
 	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_POST_DATA))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -141,9 +141,18 @@ copydb_process_table_data(CopyDataSpec *specs)
 		}
 
 		/*
-		 * Start as many index worker process as --index-jobs
+		 * Start as many index worker process as --index-jobs.
+		 * When --defer-indexes is used with --follow, skip this step
+		 * entirely; STEP 10 will create all indexes using pgcopydb's
+		 * parallel workers in the parent process.
 		 */
-		if (errors == 0 && !copydb_start_index_supervisor(specs))
+		if (specs->deferIndexes && specs->follow)
+		{
+			log_info("STEP 6: skipping CREATE INDEX (--defer-indexes)");
+			log_info("STEP 7: skipping constraints (--defer-indexes)");
+			log_info("STEP 8: skipping VACUUM (--defer-indexes)");
+		}
+		else if (errors == 0 && !copydb_start_index_supervisor(specs))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -153,8 +162,13 @@ copydb_process_table_data(CopyDataSpec *specs)
 		 * Now create as many VACUUM ANALYZE sub-processes as needed, per
 		 * --table-jobs. Could be exposed separately as --vacuumJobs too, but
 		 * that's not been done at this time.
+		 *
+		 * When --defer-indexes is used with --follow, skip VACUUM here:
+		 * the index supervisor (which sends STOP to vacuum workers) is
+		 * not started, so vacuum workers would hang forever.
 		 */
-		if (errors == 0 && !vacuum_start_supervisor(specs))
+		if (errors == 0 && !(specs->deferIndexes && specs->follow) &&
+			!vacuum_start_supervisor(specs))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -347,7 +361,7 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 		{
 			(void) copydb_fatal_exit();
 		}
-		else
+		else if (!(specs->deferIndexes && specs->follow))
 		{
 			/* send create index workers a STOP message */
 			if (!copydb_index_workers_send_stop(specs))
@@ -365,7 +379,7 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 		return false;
 	}
 
-	if (specs->deferIndexes)
+	if (specs->deferIndexes && !specs->follow)
 	{
 		log_info("COPY phase complete, queueing all deferred indexes");
 
@@ -385,8 +399,15 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 	/*
 	 * Now that the COPY processes are done, signal this is the end to the
 	 * CREATE INDEX sub-processes by adding the STOP message to
-	 * their queues.
+	 * their queues.  When --defer-indexes --follow, no index workers were
+	 * started so skip this.
 	 */
+	if (specs->deferIndexes && specs->follow)
+	{
+		/* no index workers to stop */
+		return true;
+	}
+
 	if (!copydb_index_workers_send_stop(specs))
 	{
 		/*
@@ -1027,7 +1048,8 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 
 			if (tableSpecs->sourceTable->indexCount == 0)
 			{
-				if (!specs->skipVacuum)
+				if (!specs->skipVacuum &&
+					!(specs->deferIndexes && specs->follow))
 				{
 					SourceTable *sourceTable = tableSpecs->sourceTable;
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -73,7 +73,7 @@ exclude-extension: build
 blob-snapshot-release:
 	$(MAKE) -C $@
 
-follow-defer-indexes:
+follow-defer-indexes: build
 	$(MAKE) -C $@
 
 timescaledb: build

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,8 @@ BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 all: pagila pagila-multi-steps blobs unit filtering filtering-standby extensions \
 	 cdc-wal2json cdc-test-decoding cdc-endpos-between-transaction cdc-low-level \
 	 follow-wal2json follow-standby follow-9.6 follow-data-only \
-	 endpos-in-multi-wal-txn exclude-extension;
+	 endpos-in-multi-wal-txn exclude-extension \
+	 blob-snapshot-release follow-defer-indexes;
 
 pagila: build
 	$(MAKE) -C $@
@@ -69,6 +70,12 @@ endpos-in-multi-wal-txn: build
 exclude-extension: build
 	$(MAKE) -C $@
 
+blob-snapshot-release:
+	$(MAKE) -C $@
+
+follow-defer-indexes:
+	$(MAKE) -C $@
+
 timescaledb: build
 	$(MAKE) -C $@
 
@@ -81,3 +88,4 @@ build:
 .PHONY: cdc-wal2json cdc-test-decoding cdc-low-level
 .PHONY: follow-wal2json follow-standby follow-9.6
 .PHONY: endpos-in-multi-wal-txn exclude-extension
+.PHONY: blob-snapshot-release follow-defer-indexes

--- a/tests/blob-snapshot-release/Dockerfile
+++ b/tests/blob-snapshot-release/Dockerfile
@@ -1,0 +1,8 @@
+FROM pgcopydb
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./setup.sql setup.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/blob-snapshot-release/Makefile
+++ b/tests/blob-snapshot-release/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+.PHONY: run down build test

--- a/tests/blob-snapshot-release/compose.yaml
+++ b/tests/blob-snapshot-release/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  source:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c wal_level=logical
+
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  test:
+    build: .
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+    depends_on:
+      - source
+      - target

--- a/tests/blob-snapshot-release/copydb.sh
+++ b/tests/blob-snapshot-release/copydb.sh
@@ -1,0 +1,105 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# Load test data with a large object on the source
+psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/setup.sql
+
+# Verify large objects exist (this is the code path we're testing)
+lo_count=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c \
+  "SELECT count(*) FROM pg_largeobject_metadata")
+
+echo "Source has ${lo_count} large objects"
+
+if [ "${lo_count}" -lt 1 ]; then
+    echo "ERROR: Expected at least 1 large object on the source"
+    exit 1
+fi
+
+#
+# Count idle-in-transaction connections BEFORE clone
+#
+idle_txn_before=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c \
+  "SELECT count(*) FROM pg_stat_activity
+    WHERE state = 'idle in transaction'
+      AND query LIKE '%pg_largeobject_metadata%'")
+
+echo "idle-in-transaction blob connections before clone: ${idle_txn_before}"
+
+#
+# Run pgcopydb clone (without --follow, simpler for this test)
+#
+pgcopydb clone --notice
+
+#
+# After clone completes, verify no idle-in-transaction connections remain
+# that reference the blob check query. Before the fix, the connection from
+# copydb_has_large_objects() would stay open as "idle in transaction" with
+# query "select exists(select 1 from pg_largeobject_metadata)" for the
+# entire clone duration.
+#
+idle_txn_after=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c \
+  "SELECT count(*) FROM pg_stat_activity
+    WHERE state = 'idle in transaction'
+      AND query LIKE '%pg_largeobject_metadata%'")
+
+echo "idle-in-transaction blob connections after clone: ${idle_txn_after}"
+
+if [ "${idle_txn_after}" != "0" ]; then
+    echo "ERROR: Found ${idle_txn_after} idle-in-transaction connections"
+    echo "  with pg_largeobject_metadata query after clone completed."
+    echo "  copydb_has_large_objects() is not closing its snapshot connection."
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -c \
+      "SELECT pid, state, backend_xmin, now() - xact_start AS duration, query
+         FROM pg_stat_activity
+        WHERE state = 'idle in transaction'"
+
+    exit 1
+fi
+
+#
+# Verify data was copied correctly
+#
+src_count=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c "SELECT count(*) FROM test_data")
+tgt_count=$(psql -AtX -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT count(*) FROM test_data")
+
+echo "Source rows: ${src_count}, Target rows: ${tgt_count}"
+
+if [ "${src_count}" != "${tgt_count}" ]; then
+    echo "ERROR: Row count mismatch! Source=${src_count} Target=${tgt_count}"
+    exit 1
+fi
+
+#
+# Verify large objects were copied
+#
+tgt_lo_count=$(psql -AtX -d ${PGCOPYDB_TARGET_PGURI} -c \
+  "SELECT count(*) FROM pg_largeobject_metadata")
+
+echo "Target large objects: ${tgt_lo_count}"
+
+if [ "${tgt_lo_count}" != "${lo_count}" ]; then
+    echo "ERROR: Large object count mismatch! Source=${lo_count} Target=${tgt_lo_count}"
+    exit 1
+fi
+
+echo ""
+echo "blob-snapshot-release test: PASSED"
+echo "  - copydb_has_large_objects() closed its snapshot connection"
+echo "  - No idle-in-transaction connections left behind"
+echo "  - Data and large objects copied correctly"

--- a/tests/blob-snapshot-release/setup.sql
+++ b/tests/blob-snapshot-release/setup.sql
@@ -1,0 +1,11 @@
+-- Create a test table with an index to exercise the full COPY path
+CREATE TABLE test_data (
+    id serial PRIMARY KEY,
+    val text
+);
+
+INSERT INTO test_data (val)
+SELECT 'row-' || g FROM generate_series(1, 1000) g;
+
+-- Create a large object so copydb_has_large_objects() returns true
+SELECT lo_create(0);

--- a/tests/follow-defer-indexes/Dockerfile
+++ b/tests/follow-defer-indexes/Dockerfile
@@ -1,0 +1,10 @@
+FROM pagila
+
+COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/follow-defer-indexes/Dockerfile.inject
+++ b/tests/follow-defer-indexes/Dockerfile.inject
@@ -1,0 +1,14 @@
+FROM pgcopydb
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/pgcopydb
+COPY ./inject.sh inject.sh
+COPY ./dml.sql dml.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/inject.sh"]

--- a/tests/follow-defer-indexes/Dockerfile.pg
+++ b/tests/follow-defer-indexes/Dockerfile.pg
@@ -1,0 +1,9 @@
+ARG PGVERSION=17
+FROM postgres:${PGVERSION}
+
+ARG PGVERSION=17
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
+    && rm -rf /var/lib/apt/lists/*
+USER postgres

--- a/tests/follow-defer-indexes/Makefile
+++ b/tests/follow-defer-indexes/Makefile
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	$(DOCKER) compose up $(COMPOSE_EXIT)
+
+run: build fix-volumes
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+VPATH   = /var/run/pgcopydb
+CNAME   = follow-defer-indexes
+VNAME   = follow-defer-indexes
+VOLUMES = -v $(VNAME):$(VPATH)
+OPTS    = --env-file=../paths.env $(VOLUMES)
+CLEANUP = make -f /var/lib/postgres/cleanup.mk
+
+fix-volumes:
+	$(DOCKER) run --rm $(OPTS) $(CNAME) $(CLEANUP)
+
+attach:
+	$(DOCKER) run --rm -it $(OPTS) $(CNAME) bash
+
+.PHONY: run down build test fix-volumes

--- a/tests/follow-defer-indexes/compose.yaml
+++ b/tests/follow-defer-indexes/compose.yaml
@@ -1,0 +1,94 @@
+services:
+  source:
+    image: postgres-wal2json:${PGVERSION:-17}
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+      args:
+        PGVERSION: ${PGVERSION:-17}
+    user: postgres
+    expose:
+      - 5432
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_DB: pagila
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+      -c wal_level=logical
+      -c max_wal_senders=10
+      -c max_replication_slots=10
+
+  target:
+    image: postgres:${PGVERSION:-17}
+    user: postgres
+    expose:
+      - 5432
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_DB: pagila
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  inject:
+    build:
+      context: .
+      dockerfile: Dockerfile.inject
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/pagila
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/pagila
+      TMPDIR: /var/run/pgcopydb
+      XDG_DATA_HOME: /var/run/pgcopydb/cdc
+    volumes:
+      - follow-defer-indexes:/var/run/pgcopydb
+    depends_on:
+      source:
+        condition: service_healthy
+
+  test:
+    image: follow-defer-indexes
+    build:
+      context: .
+      dockerfile: Dockerfile
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/pagila
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/pagila
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 4
+      PGCOPYDB_FAIL_FAST: "true"
+      TMPDIR: /var/run/pgcopydb
+      XDG_DATA_HOME: /var/run/pgcopydb/cdc
+    volumes:
+      - follow-defer-indexes:/var/run/pgcopydb
+    depends_on:
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy
+      inject:
+        condition: service_started
+
+volumes:
+  follow-defer-indexes:
+    external: true

--- a/tests/follow-defer-indexes/copydb.sh
+++ b/tests/follow-defer-indexes/copydb.sh
@@ -1,0 +1,160 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# ensure TMPDIR is writable by the docker user
+sudo mkdir -p ${TMPDIR}
+sudo chown -R `whoami` ${TMPDIR}
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# Load pagila schema and data on the source
+psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+
+# alter the pagila schema to allow capturing DDLs without pkey
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+#
+# Count indexes on the source before clone starts (for verification later).
+#
+src_index_count=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c \
+  "SELECT count(*)
+     FROM pg_indexes
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema')")
+
+echo "=== Source has ${src_index_count} indexes ==="
+
+if [ "${src_index_count}" -lt 1 ]; then
+    echo "ERROR: Expected at least 1 index on the source, found ${src_index_count}"
+    exit 1
+fi
+
+#
+# Count FK constraints on the source for verification.
+#
+src_fk_count=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c \
+  "SELECT count(*)
+     FROM pg_constraint
+    WHERE contype = 'f'
+      AND connamespace = 'public'::regnamespace")
+
+echo "=== Source has ${src_fk_count} foreign key constraints ==="
+
+#
+# Run pgcopydb clone --follow --defer-indexes.
+#
+# With --defer-indexes and --follow:
+#   - STEP 6 (index supervisor) is skipped during the COPY phase
+#   - STEP 7 (constraints) is skipped during the COPY phase
+#   - STEP 8 (vacuum) is skipped during the COPY phase
+#   - Clone subprocess exits early after COPY + blobs
+#   - Parent process runs STEP 10 which builds indexes via
+#     copydb_copy_all_indexes() using CREATE INDEX (ShareLock) + ALTER
+#     TABLE ADD CONSTRAINT USING INDEX, then pg_restore handles remaining
+#     post-data items (triggers, etc.)
+#
+# The inject service will:
+#   1. Wait for the clone to start
+#   2. Verify the snapshot is released after COPY completes
+#   3. Inject DML changes and set endpos
+#
+pgcopydb clone \
+         --follow \
+         --defer-indexes \
+         --plugin wal2json \
+         --notice
+
+# cleanup
+pgcopydb stream sentinel get
+
+# make sure the inject service has had time to see the final sentinel values
+sleep 2
+pgcopydb stream cleanup
+
+#
+# Verify data matches between source and target.
+#
+sql="select count(*), sum(amount) from payment"
+
+src_result=`psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}"`
+tgt_result=`psql -AtX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
+
+echo "Source: ${src_result}"
+echo "Target: ${tgt_result}"
+
+if [ "${src_result}" != "${tgt_result}" ]; then
+    echo "ERROR: Source and target payment data do not match!"
+    echo "  Source: ${src_result}"
+    echo "  Target: ${tgt_result}"
+    exit 1
+fi
+
+#
+# Verify that indexes exist on the target (built by STEP 10).
+#
+tgt_index_count=$(psql -AtX -d ${PGCOPYDB_TARGET_PGURI} -c \
+  "SELECT count(*)
+     FROM pg_indexes
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema')")
+
+echo "Source index count: ${src_index_count}"
+echo "Target index count: ${tgt_index_count}"
+
+if [ "${tgt_index_count}" -lt "${src_index_count}" ]; then
+    echo "ERROR: Target has fewer indexes (${tgt_index_count}) than source (${src_index_count})!"
+    echo "  This means STEP 10 did not build all indexes."
+    exit 1
+fi
+
+#
+# Verify FK constraints exist on the target.
+#
+tgt_fk_count=$(psql -AtX -d ${PGCOPYDB_TARGET_PGURI} -c \
+  "SELECT count(*)
+     FROM pg_constraint
+    WHERE contype = 'f'
+      AND connamespace = 'public'::regnamespace")
+
+echo "Source FK count: ${src_fk_count}"
+echo "Target FK count: ${tgt_fk_count}"
+
+if [ "${tgt_fk_count}" -lt "${src_fk_count}" ]; then
+    echo "ERROR: Target has fewer FK constraints (${tgt_fk_count}) than source (${src_fk_count})!"
+    exit 1
+fi
+
+#
+# Verify a known primary key exists.
+#
+actor_pk=$(psql -AtX -d ${PGCOPYDB_TARGET_PGURI} -c \
+  "SELECT count(*)
+     FROM pg_indexes
+    WHERE indexname = 'actor_pkey'")
+
+if [ "${actor_pk}" != "1" ]; then
+    echo "ERROR: actor_pkey index not found on target!"
+    exit 1
+fi
+
+echo ""
+echo "follow-defer-indexes test: PASSED"
+echo ""
+echo "Clone --follow --defer-indexes completed successfully:"
+echo "  - STEP 6/7/8 were deferred to STEP 10"
+echo "  - STEP 10 built ${tgt_index_count} indexes via parallel CREATE INDEX"
+echo "  - ${tgt_fk_count} FK constraints created"
+echo "  - Data is consistent between source and target"
+echo "  - CDC replay worked correctly with deferred indexes"

--- a/tests/follow-defer-indexes/ddl.sql
+++ b/tests/follow-defer-indexes/ddl.sql
@@ -1,0 +1,14 @@
+---
+--- pgcopydb test/cdc/ddl.sql
+---
+--- This file implements DDL changes in the pagila database.
+
+begin;
+alter table payment_p2022_01 replica identity full;
+alter table payment_p2022_02 replica identity full;
+alter table payment_p2022_03 replica identity full;
+alter table payment_p2022_04 replica identity full;
+alter table payment_p2022_05 replica identity full;
+alter table payment_p2022_06 replica identity full;
+alter table payment_p2022_07 replica identity full;
+commit;

--- a/tests/follow-defer-indexes/dml.sql
+++ b/tests/follow-defer-indexes/dml.sql
@@ -1,0 +1,50 @@
+---
+--- pgcopydb test/cdc/dml.sql
+---
+--- This file implements DML changes in the pagila database.
+
+\set customerid1 291
+\set customerid2 292
+
+\set staffid1 1
+\set staffid2 2
+
+\set inventoryid1 371
+\set inventoryid2 1097
+
+begin;
+
+with r as
+ (
+   insert into rental(rental_date, inventory_id, customer_id, staff_id, last_update)
+        select '2022-06-01', :inventoryid1, :customerid1, :staffid1, '2022-06-01'
+     returning rental_id, customer_id, staff_id
+ )
+ insert into payment(customer_id, staff_id, rental_id, amount, payment_date)
+      select customer_id, staff_id, rental_id, 5.99, '2022-06-01'
+        from r;
+
+commit;
+
+-- update 10 rows in a single UPDATE command
+update public.payment set amount = 11.95 where amount = 11.99;
+
+begin;
+
+delete from payment
+      using rental
+      where rental.rental_id = payment.rental_id
+        and rental.last_update = '2022-06-01';
+
+delete from rental where rental.last_update = '2022-06-01';
+
+commit;
+
+--
+-- update the payments back to their original values
+--
+begin;
+
+update public.payment set amount = 11.99 where amount = 11.95;
+
+commit;

--- a/tests/follow-defer-indexes/inject.sh
+++ b/tests/follow-defer-indexes/inject.sh
@@ -1,0 +1,134 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+
+# ensure TMPDIR is writable
+sudo mkdir -p ${TMPDIR}
+sudo chown -R `whoami` ${TMPDIR}
+
+pgcopydb ping
+
+#
+# Wait for the pgcopydb schema catalog (source.db) to exist, indicating
+# that the test service has loaded the schema and started clone --follow.
+#
+dbfile=${TMPDIR}/pgcopydb/schema/source.db
+
+until [ -s ${dbfile} ]
+do
+    sleep 1
+done
+
+echo "=== source.db exists, pgcopydb has started ==="
+
+#
+# Wait for the TIMING_SECTION_SNAPSHOT_DONE signal in the SQLite catalog.
+# This is written by the clone subprocess after COPY completes. With
+# --defer-indexes --follow, the clone subprocess exits after this signal,
+# and the parent process releases the snapshot.
+#
+echo "=== Waiting for COPY phase to complete (snapshot-done signal) ==="
+
+snapshot_done=false
+for i in $(seq 120)
+do
+    # Query the SQLite catalog for the snapshot-done timing entry
+    done_time=$(sqlite3 -batch -bail -noheader ${dbfile} \
+        "SELECT COALESCE(done_time_epoch, 0) FROM timings
+          WHERE label = 'Snapshot Done'" 2>/dev/null || echo "0")
+
+    if [ "${done_time}" != "0" ] && [ "${done_time}" != "" ]; then
+        echo "=== snapshot-done signal found, COPY phase is complete ==="
+        snapshot_done=true
+        break
+    fi
+    sleep 1
+done
+
+if [ "${snapshot_done}" != "true" ]; then
+    echo "ERROR: Timed out waiting for snapshot-done signal after 120 seconds"
+    echo "  The COPY phase did not complete or the signal was not written."
+    exit 1
+fi
+
+# Give the parent process time to close the snapshot
+sleep 5
+
+#
+# Verify the slot's xmin is now NULL (snapshot released after COPY).
+# This is the key assertion for the early-release feature.
+#
+echo "=== Slot state after COPY phase ==="
+psql -d ${PGCOPYDB_SOURCE_PGURI} -c \
+    "SELECT slot_name, xmin, catalog_xmin, active, restart_lsn
+       FROM pg_replication_slots
+      WHERE slot_name = 'pgcopydb'"
+
+slot_xmin=$(psql -AtX -d ${PGCOPYDB_SOURCE_PGURI} -c \
+    "SELECT COALESCE(xmin::text, 'NULL')
+       FROM pg_replication_slots
+      WHERE slot_name = 'pgcopydb'")
+
+echo "Slot xmin after COPY: ${slot_xmin}"
+
+if [ "${slot_xmin}" != "NULL" ]; then
+    echo "ERROR: Slot xmin is still set to ${slot_xmin}"
+    echo "  Expected NULL after COPY phase completes."
+    echo "  The snapshot was not released — this is the bug we are fixing."
+    exit 1
+fi
+
+echo "=== VERIFIED: xmin is NULL — snapshot released after COPY ==="
+
+#
+# Now inject DML changes while the parent continues with STEP 10 (indexes).
+# This exercises the CDC path after the snapshot was released.
+#
+echo "=== Injecting DML changes ==="
+
+for i in $(seq 5)
+do
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 1
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 1
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_switch_wal()'
+    sleep 1
+done
+
+# grab the current LSN, it's going to be our streaming end position
+lsn=$(psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_flush_lsn()')
+
+pgcopydb stream sentinel set endpos --current --debug
+pgcopydb stream sentinel get
+
+endpos=$(pgcopydb stream sentinel get --endpos 2>/dev/null)
+
+if [ "${endpos}" = "0/0" ]; then
+    echo "expected ${lsn} endpos, found ${endpos}"
+    exit 1
+fi
+
+#
+# Wait for pgcopydb to catch up to the endpos.
+#
+flushlsn="0/0"
+
+while [ "${flushlsn}" \< "${endpos}" ]
+do
+    flushlsn=$(pgcopydb stream sentinel get --flush-lsn 2>/dev/null)
+    sleep 1
+done
+
+#
+# Give the test service time to finish cleanup.
+#
+sleep 10


### PR DESCRIPTION
## Summary

- **Fix blob snapshot connection leak**: `copydb_has_large_objects()` opens a REPEATABLE READ snapshot connection to check `pg_largeobject_metadata` but never closes it, pinning `backend_xmin` on the source through index building and post-data restore, preventing VACUUM from advancing. The fix closes the connection immediately after the query.
- **Defer index creation to parent process with `--defer-indexes --follow`**: When both flags are used, STEP 6 (CREATE INDEX), STEP 7 (constraints), and STEP 8 (VACUUM) are skipped in the clone subprocess. The clone child exits after COPY + blobs, releasing all source connections early. The parent process then builds indexes using parallel workers after the snapshot is released.
- **Wire new test suites into CI**: Add `blob-snapshot-release` and `follow-defer-indexes` test suites to the Makefile and GitHub Actions matrix.

## Test plan

- [x] `blob-snapshot-release` test suite passes on PG 16, 17, 18
- [x] `follow-defer-indexes` test suite passes on PG 16, 17, 18
- [x] All 26 existing test suites pass on PG 16, 17, 18 (78 runs, zero failures)
- [x] `citus_indent` style check passes