### PR TITLE
Move snapshot-done signal into COPY supervisor for earlier release

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -752,13 +752,23 @@ cloneDB(CopyDataSpec *copySpecs)
 		return false;
 	}
 
-	/* Signal parent that snapshot-dependent work is complete */
-	if (!summary_start_timing(sourceDB, TIMING_SECTION_SNAPSHOT_DONE) ||
-		!summary_stop_timing(sourceDB, TIMING_SECTION_SNAPSHOT_DONE))
-	{
-		log_warn("Failed to write snapshot-done signal");
+	/*
+	 * Fallback: write snapshot-done signal if COPY supervisor didn't
+	 * (e.g. zero tables, or COPY supervisor failed before writing it).
+	 */
+	TopLevelTiming snDoneTiming = { 0 };
 
-		/* Non-fatal: parent falls back to closing snapshot after clone exits */
+	if (!summary_lookup_timing(sourceDB, &snDoneTiming,
+							   TIMING_SECTION_SNAPSHOT_DONE) ||
+		snDoneTiming.doneTime == 0)
+	{
+		if (!summary_start_timing(sourceDB, TIMING_SECTION_SNAPSHOT_DONE) ||
+			!summary_stop_timing(sourceDB, TIMING_SECTION_SNAPSHOT_DONE))
+		{
+			log_warn("Failed to write snapshot-done signal");
+
+			/* Non-fatal: parent falls back to closing snapshot after clone exits */
+		}
 	}
 
 	/*

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -379,6 +379,19 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 		return false;
 	}
 
+	/*
+	 * Signal parent that all snapshot-dependent COPY work is complete.
+	 * The parent polls for this and releases the exported snapshot so
+	 * VACUUM can advance on the source while indexes are still building.
+	 */
+	if (!summary_start_timing(sourceDB, TIMING_SECTION_SNAPSHOT_DONE) ||
+		!summary_stop_timing(sourceDB, TIMING_SECTION_SNAPSHOT_DONE))
+	{
+		log_warn("Failed to write snapshot-done signal from COPY supervisor");
+
+		/* Non-fatal: parent falls back to closing snapshot after clone exits */
+	}
+
 	if (specs->deferIndexes && !specs->follow)
 	{
 		log_info("COPY phase complete, queueing all deferred indexes");


### PR DESCRIPTION
## Summary

- Move the `TIMING_SECTION_SNAPSHOT_DONE` signal write from `cloneDB()` (after all of `copydb_copy_all_table_data` returns, including index builds and vacuum) into `copydb_copy_supervisor()` (right after COPY workers finish). This releases the exported snapshot as soon as COPY completes, allowing VACUUM to advance on the source while indexes are still building on the target.
- The existing signal in `cloneDB()` is kept as a conditional fallback for edge cases where the COPY supervisor didn't run (zero tables).

Previously the snapshot was held through COPY + index builds + vacuum before being released. On large databases (e.g. 30TB with 13TB of indexes), this could pin `backend_xmin` on the source for hours unnecessarily.

## Test plan

- [x] `pagila`, `blobs`, `follow-wal2json`, `unit`, `skip-vacuum` pass on PG 16
- [x] Full 24-suite run on PG 17 and PG 18 (in progress)