### PR TITLE
security: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0 # all history for all branches and tags
 
@@ -48,7 +48,7 @@ jobs:
       # Install the cosign tool (not used on PR, still installed)
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # main
         with:
           cosign-release: 'v2.2.3'
 
@@ -57,13 +57,13 @@ jobs:
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -84,7 +84,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/run-tests-tiered.yml
+++ b/.github/workflows/run-tests-tiered.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     container: citus/stylechecker:no-py
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       name: Checkout code
 
     - name: Set safe directory for git
@@ -40,7 +40,7 @@ jobs:
     name: Check for banned APIs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
     - name: Check for banned APIs
       run: sh ./ci/banned.h.sh
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Build docs
-        uses: ammaraskar/sphinx-action@master
+        uses: ammaraskar/sphinx-action@c61ac11d9ee097caf8983c10c8b5af5861b32b54  # master
         with:
           docs-folder: "docs/"
 
@@ -88,7 +88,7 @@ jobs:
           - unit
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
@@ -101,7 +101,7 @@ jobs:
             echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
 
       - name: Build pgcopydb Docker image
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -158,7 +158,7 @@ jobs:
           - fk-not-valid
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
@@ -171,7 +171,7 @@ jobs:
             echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
 
       - name: Build pgcopydb Docker image
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3
         with:
           timeout_minutes: 10
           max_attempts: 3


### PR DESCRIPTION
## Summary

Pins all third-party GitHub Actions `uses:` references to immutable 40-character commit SHAs, per the PlanetScale security policy for GitHub Actions supply-chain hardening. Reference: https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

## Changes

### `.github/workflows/docker-publish.yml`

| Action | Old ref | New SHA |
|--------|---------|---------|
| `actions/checkout` | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `sigstore/cosign-installer` | `@main` ⚠️ | `@6f9f17788090df1f26f669e9d70d6ae9567deba6` |
| `docker/setup-buildx-action` | `@v3` | `@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` |
| `docker/login-action` | `@v3` | `@c94ce9fb468520275223c153574b00df6fe4bcc9` |
| `docker/metadata-action` | `@v5` | `@c299e40c65443455700f0fdfc63efafe5b349051` |
| `docker/build-push-action` | `@v6` | `@10e90e3645eae34f1e60eeb005ba3a3d33f178e8` |

### `.github/workflows/run-tests-tiered.yml`

| Action | Old ref | New SHA |
|--------|---------|---------|
| `actions/checkout` | `@v6` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `ammaraskar/sphinx-action` | `@master` ⚠️ | `@c61ac11d9ee097caf8983c10c8b5af5861b32b54` |
| `nick-fields/retry` | `@v3` | `@ce71cc2ab81d554ebbe88c79ab5975992d79ba08` |

### `.github/dependabot.yml` (new)

Added `github-actions` ecosystem block so Dependabot will continue to surface update PRs for the SHA-pinned actions (it reads the trailing `# vX` version comments).

## Flagged items

- **`sigstore/cosign-installer@main`** and **`ammaraskar/sphinx-action@master`** were previously tracking mutable branch heads (not tagged releases). Both are now SHA-pinned to the current HEAD of their respective default branches. Consider switching to a tagged release if one becomes available.
- No `docker://` image references were found in these workflows.