### PR TITLE
Fix split-table TRUNCATE on resume (data-loss path)

### DIFF
--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -611,24 +611,63 @@ copydb_copy_supervisor_add_table_hook(void *ctx, SourceTable *table)
 		 * Add as many times the table OID as we have partitions, each with
 		 * their own partition number that starts at 1 (not zero).
 		 *
-		 * Before adding the table to be processed by workers, truncate it on
-		 * the target database now, avoiding concurrency issues.
+		 * Before adding the table to be processed by workers, we normally
+		 * TRUNCATE it on the target database to give all per-part workers a
+		 * clean slate (per-part workers do not TRUNCATE themselves).
+		 *
+		 * On --resume, when one or more parts of this table were already
+		 * COPYed successfully in a previous run, their rows live on the
+		 * target and the per-part worker for those parts will skip the COPY.
+		 * Truncating here would discard that good data, so we only TRUNCATE
+		 * when no parts of this table are marked done in the catalog.
+		 * If every part is already done we also skip enqueueing the parts.
 		 */
-		bool granted = false;
+		DatabaseCatalog *sourceDB = &(specs->catalogs.source);
+		CopyTableDataSpec partsDoneSpec = { 0 };
 
-		if (!pgsql_has_table_privilege(dst, table->qname, "TRUNCATE", &granted))
+		partsDoneSpec.sourceTable = table;
+
+		if (!summary_table_count_parts_done(sourceDB, &partsDoneSpec))
 		{
 			/* errors have already been logged */
 			return false;
 		}
 
-		if (granted)
+		if (partsDoneSpec.countPartsDone == 0)
 		{
-			if (!pgsql_truncate(dst, table->qname))
+			bool granted = false;
+
+			if (!pgsql_has_table_privilege(dst, table->qname,
+										   "TRUNCATE", &granted))
 			{
 				/* errors have already been logged */
 				return false;
 			}
+
+			if (granted)
+			{
+				if (!pgsql_truncate(dst, table->qname))
+				{
+					/* errors have already been logged */
+					return false;
+				}
+			}
+		}
+		else if (partsDoneSpec.countPartsDone >= (uint32_t) table->partition.partCount)
+		{
+			log_info("Skipping table %s on resume: "
+					 "all %d parts already done in a previous run",
+					 table->qname,
+					 table->partition.partCount);
+			return true;
+		}
+		else
+		{
+			log_notice("Skipping TRUNCATE of %s on resume: "
+					   "%u of %d parts already done in a previous run",
+					   table->qname,
+					   partsDoneSpec.countPartsDone,
+					   table->partition.partCount);
 		}
 
 		for (int i = 0; i < table->partition.partCount; i++)

--- a/tests/unit/expected/5-split-resume.out
+++ b/tests/unit/expected/5-split-resume.out
@@ -1,0 +1,4 @@
+source-rows: 100
+target-rows-after-first-run: 100
+marker-survived-resume: 1
+target-rows-after-resume: 101

--- a/tests/unit/script/5-split-resume.sh
+++ b/tests/unit/script/5-split-resume.sh
@@ -1,0 +1,74 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Regression test for the split-table TRUNCATE-on-resume bug.
+#
+# Before the fix, copydb_copy_supervisor_add_table_hook (table-data.c)
+# unconditionally issued TRUNCATE on every partitioned table on every
+# supervisor invocation, including --resume runs. Per-part workers then
+# saw doneTime > 0 in the summary catalog and skipped the COPY — leaving
+# the table empty.
+#
+# This script reproduces the data-loss path:
+#   1. seed a fresh target table
+#   2. run `pgcopydb copy table-data` with split-tables enabled (parts done)
+#   3. drop a marker row into target — it exists only on target, not source
+#   4. re-run with --resume
+#   5. with the fix: TRUNCATE is gated on no parts being done, the marker
+#      survives, and the original split-copied rows are preserved.
+
+DIR=/tmp/unit/split-resume
+TBL=public.table_1
+FILTERS="$DIR/include-table_1.ini"
+
+rm -rf "$DIR"
+mkdir -p "$DIR"
+cat > "$FILTERS" <<EOF
+[include-only-table]
+${TBL}
+EOF
+
+# Schema is already present on target from the unit suite's `pgcopydb fork`,
+# but data was copied as a whole table (not split). Reset the target table so
+# we can drive the split-copy + resume path explicitly.
+psql -q -d "${PGCOPYDB_TARGET_PGURI}" -c "TRUNCATE ${TBL}" >/dev/null
+
+# First run: copy table-data with a 10kB split threshold. table_1 holds
+# 100 rows of char(580) — well over the threshold, so it splits.
+PGCOPYDB_SPLIT_TABLES_LARGER_THAN=10kB \
+    pgcopydb copy table-data \
+        --dir "$DIR" \
+        --not-consistent \
+        --filters "$FILTERS" \
+        --table-jobs 2
+
+SRC_COUNT=$(psql -tA -d "${PGCOPYDB_SOURCE_PGURI}" -c "SELECT count(*) FROM ${TBL}")
+TGT_COUNT=$(psql -tA -d "${PGCOPYDB_TARGET_PGURI}" -c "SELECT count(*) FROM ${TBL}")
+echo "source-rows: ${SRC_COUNT}"
+echo "target-rows-after-first-run: ${TGT_COUNT}"
+
+# Drop a marker row that does NOT exist on the source — if --resume issues
+# TRUNCATE, this marker disappears along with the originally-copied rows.
+psql -q -d "${PGCOPYDB_TARGET_PGURI}" \
+    -c "INSERT INTO ${TBL}(c_char) VALUES ('marker-row')" >/dev/null
+
+# Second run with --resume: the per-part summary entries from the first run
+# mean every part is already done. With the fix the supervisor skips the
+# table-level TRUNCATE; without the fix it would wipe the table.
+PGCOPYDB_SPLIT_TABLES_LARGER_THAN=10kB \
+    pgcopydb copy table-data \
+        --dir "$DIR" \
+        --resume \
+        --not-consistent \
+        --filters "$FILTERS" \
+        --table-jobs 2
+
+# The marker row's survival is the proof that no TRUNCATE happened.
+MARKER=$(psql -tA -d "${PGCOPYDB_TARGET_PGURI}" \
+    -c "SELECT count(*) FROM ${TBL} WHERE c_char = 'marker-row'")
+TGT_COUNT_AFTER=$(psql -tA -d "${PGCOPYDB_TARGET_PGURI}" \
+    -c "SELECT count(*) FROM ${TBL}")
+echo "marker-survived-resume: ${MARKER}"
+echo "target-rows-after-resume: ${TGT_COUNT_AFTER}"


### PR DESCRIPTION
## Summary

The COPY supervisor's per-table hook (`copydb_copy_supervisor_add_table_hook` in `table-data.c`) truncated every partitioned table unconditionally — including on `--resume` runs. Per-part workers then saw `done_time_epoch > 0` in the summary catalog and skipped the COPY, leaving the table empty and losing previously-copied data.

Most reliably triggered by `--split-tables-larger-than` combined with `--defer-indexes`, where resume re-enters the supervisor after the COPY phase finishes but before the deferred index build (STEP 10) completes.

**Impact:** a large migration that hit a failure after the COPY phase and attempted `--resume` had every split table truncated and re-copied, undoing completed work. No corruption — purely lost progress / wasted re-copy.

## Fix

The hook now consults `summary_table_count_parts_done` before truncating a partitioned table:

- **No parts done** → TRUNCATE as before (unchanged first-run behavior).
- **All parts done** → skip TRUNCATE and skip enqueueing entirely.
- **Some parts done** → skip TRUNCATE; enqueue all parts. Per-part workers skip the done ones via the existing lockfile check; undone ones COPY into the table normally.

The in-flight-rollback case stays safe: Postgres COPY is atomic in its transaction, so an interrupted part leaves no rows behind, and the existing stale-PID path clears the summary entry.

## Test plan

- New regression test `tests/unit/script/5-split-resume.sh` drives `pgcopydb copy table-data --split-tables-larger-than 10kB` twice (second with `--resume`) and asserts a target-only marker row survives. Without the fix the marker is wiped by the supervisor's TRUNCATE.
- Full suite (`PGVERSION=16 make tests`) green on PG16 — no regressions in CDC / follow / defer-indexes / blobs suites.
