### PR TITLE
Add retry with backoff to follow pipeline on target connection failure

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,12 +6,12 @@ name: Docker
 # documentation.
 
 on:
+  # Build and publish the container image only on release (version tags).
+  # Not on every push to main or on PRs — the test workflow builds its own
+  # image per job, so a PR/main build here is redundant CI cost.
   push:
-    branches: [ main ]
-    # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 # Cancel redundant runs on the same PR/branch
 concurrency:

--- a/.github/workflows/run-tests-tiered.yml
+++ b/.github/workflows/run-tests-tiered.yml
@@ -152,6 +152,7 @@ jobs:
           - follow-standby
           - follow-9.6
           - follow-data-only
+          - follow-target-reconnect
           - endpos-in-multi-wal-txn
           - blob-snapshot-release
           - follow-defer-indexes

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -272,9 +272,10 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	}
 
 	/*
-	 * In case of successful exit from the follow sub-processes, we
-	 * switch back and forth between CATCHUP and REPLAY modes and
-	 * continue replaying changes. In case of error, we stop.
+	 * Switch back and forth between CATCHUP and REPLAY modes, continuing
+	 * until endpos is reached. Connection-level failures are handled within
+	 * the prefetch and apply subprocesses themselves with per-subprocess
+	 * backoff and reconnect logic.
 	 */
 	LogicalStreamMode modeArray[] = {
 		STREAM_MODE_CATCHUP,
@@ -291,8 +292,7 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	{
 		if (!followDB(copySpecs, streamSpecs))
 		{
-			log_error("Failed to follow changes from source, "
-					  "see above for details");
+			log_error("Follow pipeline failed, see above for details");
 			return false;
 		}
 

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -1529,7 +1529,30 @@ setupReplicationOrigin(StreamApplyContext *context)
 			  LSN_FORMAT_ARGS(context->previousLSN),
 			  context->sqlFileName);
 
-	if (!pgsql_replication_origin_session_setup(applyPgConn, nodeName))
+	bool sessionOk =
+		pgsql_replication_origin_session_setup(applyPgConn, nodeName);
+
+	if (!sessionOk && pgsql_is_origin_in_use_error(applyPgConn))
+	{
+		/*
+		 * Another backend is still holding the replication origin session
+		 * (SQLSTATE 55006). This happens when the client-side connection was
+		 * killed by a network failure but the server-side backend has not yet
+		 * detected the dead connection. Terminate that backend and retry once.
+		 */
+		log_warn("Replication origin \"%s\" is already held by another "
+				 "backend; terminating it and retrying session setup",
+				 nodeName);
+
+		if (pgsql_terminate_origin_holder(&context->controlPgConn, applyPgConn, nodeName))
+		{
+			pg_usleep(500 * 1000); /* 500ms for the backend to exit */
+			sessionOk =
+				pgsql_replication_origin_session_setup(applyPgConn, nodeName);
+		}
+	}
+
+	if (!sessionOk)
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -27,7 +27,33 @@
 typedef struct ReplayStreamCtx
 {
 	StreamApplyContext applyContext;
+
+	/* reconnect state */
+	bool connectionFailed;      /* target connection died, need to reconnect */
+	bool drainPipe;             /* skip execution until next txn boundary */
+	bool drainComplete;         /* drain finished (saw COMMIT or ROLLBACK) */
+	int skippedStmtCount;       /* statements skipped during drain */
 } ReplayStreamCtx;
+
+
+/*
+ * apply_connection_failed returns true when either apply connection is gone.
+ * Called after stream_apply_sql returns false to distinguish connection
+ * failures (retriable) from real SQL errors (not retriable).
+ */
+static bool
+apply_connection_failed(StreamApplyContext *context)
+{
+	bool applyBad =
+		context->applyPgConn.connection == NULL ||
+		PQstatus(context->applyPgConn.connection) == CONNECTION_BAD;
+
+	bool controlBad =
+		context->controlPgConn.connection == NULL ||
+		PQstatus(context->controlPgConn.connection) == CONNECTION_BAD;
+
+	return applyBad || controlBad;
+}
 
 
 /*
@@ -75,11 +101,129 @@ stream_apply_replay(StreamSpecs *specs)
 		.ctx = &ctx
 	};
 
-	if (!read_from_stream(specs->in, &readerContext))
+	int reconnectAttempt = 0;
+	time_t reconnectWindowStart = 0;
+
+	while (true)
 	{
-		log_error("Failed to read SQL lines from input stream, "
-				  "see above for details");
-		return false;
+		if (!read_from_stream(specs->in, &readerContext))
+		{
+			log_error("Failed to read SQL lines from input stream, "
+					  "see above for details");
+			return false;
+		}
+
+		if (!ctx.connectionFailed)
+		{
+			/* normal pipe EOF: done */
+			break;
+		}
+
+		/*
+		 * Target connection was lost. If we were mid-transaction, drain the
+		 * pipe to the next COMMIT/ROLLBACK before attempting to reconnect.
+		 * The partial transaction was already rolled back on the target.
+		 */
+		if (ctx.drainPipe)
+		{
+			log_debug("Draining pipe to next transaction boundary "
+					  "before reconnecting to target");
+
+			if (!read_from_stream(specs->in, &readerContext))
+			{
+				/*
+				 * Pipe closed before we found the boundary — that's fine,
+				 * the transaction was rolled back on the target already.
+				 */
+				log_warn("Pipe closed mid-drain; partial transaction "
+						 "was rolled back on target");
+				ctx.drainPipe = false;
+				ctx.drainComplete = true;
+			}
+		}
+
+		/* record the start of this reconnect window */
+		if (reconnectWindowStart == 0)
+		{
+			reconnectWindowStart = time(NULL);
+		}
+
+		/* inner loop: attempt reconnect with exponential backoff */
+		bool reconnected = false;
+
+		while (!reconnected)
+		{
+			if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+			{
+				return false;
+			}
+
+			int elapsed = (int) (time(NULL) - reconnectWindowStart);
+
+			if (elapsed >= STREAM_RECONNECT_MAX_TOTAL_SECS)
+			{
+				log_error("Target connection lost and could not reconnect "
+						  "within %d minutes; manual intervention required",
+						  STREAM_RECONNECT_MAX_TOTAL_SECS / 60);
+				return false;
+			}
+
+			pgsql_finish(&context->applyPgConn);
+			pgsql_finish(&context->controlPgConn);
+
+			int sleepSecs =
+				STREAM_RECONNECT_BASE_SLEEP_SECS * (1 << reconnectAttempt);
+
+			if (sleepSecs > STREAM_RECONNECT_MAX_SLEEP_SECS)
+			{
+				sleepSecs = STREAM_RECONNECT_MAX_SLEEP_SECS;
+			}
+
+			log_warn("Target connection lost, reconnecting in %ds "
+					 "(attempt %d, %ds/%ds elapsed)",
+					 sleepSecs,
+					 reconnectAttempt + 1,
+					 elapsed,
+					 STREAM_RECONNECT_MAX_TOTAL_SECS);
+
+			for (int s = 0; s < sleepSecs; s++)
+			{
+				if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+				{
+					return false;
+				}
+				pg_usleep(1000 * 1000);
+			}
+
+			++reconnectAttempt;
+
+			if (!setupReplicationOrigin(context))
+			{
+				if (pgsql_is_permissions_error(&context->applyPgConn) ||
+					pgsql_is_permissions_error(&context->controlPgConn))
+				{
+					log_error("Target connection failed with authorization "
+							  "error; manual intervention required");
+					return false;
+				}
+
+				/* connection failure: keep retrying */
+				continue;
+			}
+
+			reconnected = true;
+		}
+
+		log_info("Reconnected to target database after %ds",
+				 (int) (time(NULL) - reconnectWindowStart));
+
+		/* reset reconnect state for next potential failure */
+		reconnectAttempt = 0;
+		reconnectWindowStart = 0;
+		ctx.connectionFailed = false;
+		ctx.drainPipe = false;
+		ctx.drainComplete = false;
+		ctx.skippedStmtCount = 0;
 	}
 
 	/* make sure to send a last round of sentinel update before exit */
@@ -145,6 +289,45 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 
 	LogicalMessageMetadata metadata = { 0 };
 
+	/*
+	 * Drain mode: the connection died mid-transaction. Skip execution of all
+	 * SQL until we reach the COMMIT or ROLLBACK that ends the transaction.
+	 * The partial transaction was already rolled back on the target.
+	 */
+	if (replayCtx->drainPipe)
+	{
+		if (!parseSQLAction((char *) line, &metadata, context->filters))
+		{
+			++replayCtx->skippedStmtCount;
+			return true;
+		}
+
+		if (metadata.action == STREAM_ACTION_COMMIT ||
+			metadata.action == STREAM_ACTION_ROLLBACK)
+		{
+			log_warn("Skipped partial transaction ending at LSN %X/%X after "
+					 "target connection failure: %d statement%s discarded, "
+					 "transaction was rolled back on target and will be "
+					 "replayed on reconnect from replication origin position",
+					 LSN_FORMAT_ARGS(metadata.lsn),
+					 replayCtx->skippedStmtCount,
+					 replayCtx->skippedStmtCount == 1 ? "" : "s");
+
+			replayCtx->drainPipe = false;
+			replayCtx->drainComplete = true;
+			*stop = true;
+		}
+		else
+		{
+			log_debug("Drain: skipping %s at LSN %X/%X",
+					  StreamActionToString(metadata.action),
+					  LSN_FORMAT_ARGS(metadata.lsn));
+			++replayCtx->skippedStmtCount;
+		}
+
+		return true;
+	}
+
 	if (!parseSQLAction((char *) line, &metadata, context->filters))
 	{
 		/* errors have already been logged */
@@ -153,11 +336,39 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 
 	if (!stream_apply_sql(context, &metadata, line))
 	{
+		/*
+		 * Distinguish connection failures (retriable) from real SQL errors.
+		 * On connection failure, signal the outer loop to reconnect rather
+		 * than propagating the error up through read_from_stream.
+		 */
+		if (apply_connection_failed(context))
+		{
+			log_warn("Target connection lost at LSN %X/%X during %s; "
+					 "will attempt reconnect",
+					 LSN_FORMAT_ARGS(metadata.lsn),
+					 StreamActionToString(metadata.action));
+
+			replayCtx->connectionFailed = true;
+
+			if (context->transactionInProgress)
+			{
+				log_warn("Connection lost mid-transaction at LSN %X/%X; "
+						 "draining pipe to next transaction boundary "
+						 "before reconnecting",
+						 LSN_FORMAT_ARGS(metadata.lsn));
+				replayCtx->drainPipe = true;
+				replayCtx->skippedStmtCount = 0;
+			}
+
+			*stop = true;
+			return true;
+		}
+
 		/* errors have already been logged */
 		return false;
 	}
 
-	/* update progres on source database when needed */
+	/* update progress on source database when needed */
 	switch (metadata.action)
 	{
 		/* these actions are good points when to report progress */
@@ -183,6 +394,26 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 			{
 				if (!pgsql_sync_pipeline(&(context->applyPgConn)))
 				{
+					if (apply_connection_failed(context))
+					{
+						log_warn("Target connection lost during pipeline sync; "
+								 "will attempt reconnect");
+
+						replayCtx->connectionFailed = true;
+
+						if (context->transactionInProgress)
+						{
+							log_warn("Connection lost mid-transaction during "
+									 "pipeline sync; draining pipe to next "
+									 "transaction boundary before reconnecting");
+							replayCtx->drainPipe = true;
+							replayCtx->skippedStmtCount = 0;
+						}
+
+						*stop = true;
+						return true;
+					}
+
 					log_error("Failed to sync the pipeline, see previous "
 							  "error for details");
 					return false;

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -461,11 +461,16 @@ startLogicalStreaming(StreamSpecs *specs)
 
 	/*
 	 * In case of being disconnected or other transient errors, reconnect and
-	 * continue streaming.
+	 * continue streaming. Uses exponential backoff up to a 10-minute total
+	 * window; permissions errors bail out immediately.
+	 *
+	 * reconnectWindowStart tracks when the current outage began. It resets to
+	 * zero whenever streaming makes new progress, so each new outage gets its
+	 * own fresh 10-minute window.
 	 */
 	bool retry = true;
-	uint64_t retries = 0;
-	uint64_t waterMarkLSN = InvalidXLogRecPtr;
+	int reconnectAttempt = 0;
+	time_t reconnectWindowStart = 0;
 
 	while (retry)
 	{
@@ -498,74 +503,134 @@ startLogicalStreaming(StreamSpecs *specs)
 
 		if (!pgsql_start_replication(&stream))
 		{
-			/* errors have already been logged */
-			return false;
-		}
+			if (pgsql_is_permissions_error(&stream.pgsql))
+			{
+				log_error("Source connection failed with authorization error; "
+						  "manual intervention required");
+				return false;
+			}
 
-		/* write the wal_segment_size and timeline history files */
-		if (!stream_write_context(specs, &stream))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		/* ignore errors, try again unless asked to stop */
-		bool cleanExit = pgsql_stream_logical(&stream, &context);
-
-		if (cleanExit || asked_to_stop || asked_to_stop_fast || asked_to_quit)
-		{
-			retry = false;
-		}
-
-		if (cleanExit)
-		{
-			log_info("Streamed up to write_lsn %X/%X, flush_lsn %X/%X, stopping: "
-					 "endpos is %X/%X",
-					 LSN_FORMAT_ARGS(context.tracking->written_lsn),
-					 LSN_FORMAT_ARGS(context.tracking->flushed_lsn),
-					 LSN_FORMAT_ARGS(context.endpos));
-		}
-		else if (privateContext->pipelineBroken)
-		{
-			log_error("Downstream pipeline process has exited, "
-					  "stopping at %X/%X",
-					  LSN_FORMAT_ARGS(context.tracking->written_lsn));
-
-			return false;
-		}
-		else if (retries > 0 &&
-				 context.tracking->written_lsn == waterMarkLSN)
-		{
-			log_warn("Streaming got interrupted at %X/%X, and did not make "
-					 "any progress from previous attempt, stopping now",
-					 LSN_FORMAT_ARGS(context.tracking->written_lsn));
-
-			return false;
-		}
-		else if (retry)
-		{
-			log_warn("Streaming got interrupted at %X/%X, reconnecting in 1s",
-					 LSN_FORMAT_ARGS(context.tracking->written_lsn));
+			/* connection failure: skip streaming, go straight to backoff */
 		}
 		else
 		{
-			log_warn("Streaming got interrupted at %X/%X "
-					 "after processing %lld message%s",
-					 LSN_FORMAT_ARGS(context.tracking->written_lsn),
-					 (long long) privateContext->counters.total,
-					 privateContext->counters.total > 0 ? "s" : "");
+			/* write the wal_segment_size and timeline history files */
+			if (!stream_write_context(specs, &stream))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			/*
+			 * Save start LSN for this attempt so we can detect whether
+			 * we made any new progress (used to reset the reconnect window).
+			 */
+			XLogRecPtr attemptStartLSN = specs->startpos;
+
+			/* stream until clean exit, signal, or connection failure */
+			bool cleanExit = pgsql_stream_logical(&stream, &context);
+
+			if (cleanExit || asked_to_stop || asked_to_stop_fast || asked_to_quit)
+			{
+				retry = false;
+			}
+
+			if (cleanExit)
+			{
+				log_info("Streamed up to write_lsn %X/%X, flush_lsn %X/%X, "
+						 "stopping: endpos is %X/%X",
+						 LSN_FORMAT_ARGS(context.tracking->written_lsn),
+						 LSN_FORMAT_ARGS(context.tracking->flushed_lsn),
+						 LSN_FORMAT_ARGS(context.endpos));
+			}
+			else if (privateContext->pipelineBroken)
+			{
+				log_error("Downstream pipeline process has exited, "
+						  "stopping at %X/%X",
+						  LSN_FORMAT_ARGS(context.tracking->written_lsn));
+
+				return false;
+			}
+			else if (!retry)
+			{
+				log_warn("Streaming got interrupted at %X/%X "
+						 "after processing %lld message%s",
+						 LSN_FORMAT_ARGS(context.tracking->written_lsn),
+						 (long long) privateContext->counters.total,
+						 privateContext->counters.total > 0 ? "s" : "");
+			}
+
+			/* if we are going to retry, we need to rollback the last txn */
+			context.onRetry = retry;
+
+			if (!retry)
+			{
+				break;
+			}
+
+			/*
+			 * If this attempt made new progress, it marks the end of any
+			 * previous outage — reset the reconnect window so the next
+			 * outage gets a fresh 10-minute budget.
+			 */
+			if (context.tracking != NULL &&
+				context.tracking->written_lsn > attemptStartLSN)
+			{
+				reconnectWindowStart = 0;
+				reconnectAttempt = 0;
+			}
+
+			/* update resume position from last streamed LSN */
+			if (context.tracking != NULL &&
+				context.tracking->written_lsn != InvalidXLogRecPtr)
+			{
+				specs->startpos = context.tracking->written_lsn;
+			}
 		}
 
-		/* if we are going to retry, we need to rollback the last txn */
-		context.onRetry = retry;
-
-		/* sleep for one entire second before retrying */
-		if (retry)
+		/* reconnect backoff */
+		if (reconnectWindowStart == 0)
 		{
-			++retries;
-			waterMarkLSN = context.tracking->written_lsn;
+			reconnectWindowStart = time(NULL);
+		}
 
-			(void) pg_usleep(1 * 1000 * 1000); /* 1s */
+		int elapsed = (int) (time(NULL) - reconnectWindowStart);
+
+		if (elapsed >= STREAM_RECONNECT_MAX_TOTAL_SECS)
+		{
+			log_error("Source connection lost and could not reconnect "
+					  "within %d minutes; manual intervention required",
+					  STREAM_RECONNECT_MAX_TOTAL_SECS / 60);
+			return false;
+		}
+
+		int sleepSecs =
+			STREAM_RECONNECT_BASE_SLEEP_SECS * (1 << reconnectAttempt);
+
+		if (sleepSecs > STREAM_RECONNECT_MAX_SLEEP_SECS)
+		{
+			sleepSecs = STREAM_RECONNECT_MAX_SLEEP_SECS;
+		}
+
+		log_warn("Source connection lost at %X/%X, reconnecting in %ds "
+				 "(attempt %d, %ds/%ds elapsed)",
+				 LSN_FORMAT_ARGS(context.tracking != NULL
+								 ? context.tracking->written_lsn
+								 : specs->startpos),
+				 sleepSecs,
+				 reconnectAttempt + 1,
+				 elapsed,
+				 STREAM_RECONNECT_MAX_TOTAL_SECS);
+
+		++reconnectAttempt;
+
+		for (int s = 0; s < sleepSecs; s++)
+		{
+			if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+			{
+				return false;
+			}
+			pg_usleep(1000 * 1000);
 		}
 	}
 

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -24,6 +24,11 @@
 #define OUTPUT_KEEPALIVE "-- KEEPALIVE "
 #define OUTPUT_ENDPOS "-- ENDPOS "
 
+/* Per-subprocess reconnect backoff: 5s base, 30s cap, 10-minute total window */
+#define STREAM_RECONNECT_BASE_SLEEP_SECS 5
+#define STREAM_RECONNECT_MAX_SLEEP_SECS 30
+#define STREAM_RECONNECT_MAX_TOTAL_SECS 600
+
 #define PREPARE "PREPARE "
 #define EXECUTE "EXECUTE "
 #define TRUNCATE "TRUNCATE "

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1971,13 +1971,28 @@ pgsql_sync_pipeline(PGSQL *pgsql)
 			if (res == NULL)
 			{
 				/*
-				 * NULL represents a end of result for a single query, but we are
-				 * in pipeline mode and we can have multiple results.
+				 * End of results for this statement. In pipeline mode
+				 * there may be more results pending for later statements.
 				 *
-				 * We need to continue consuming until we get a SYNC message.
+				 * We must call PQconsumeInput here to update connection
+				 * state: on a dead connection PQisBusy stays 0 and
+				 * PQgetResult returns NULL forever without PQconsumeInput
+				 * being called — an infinite spin loop.
 				 */
+				if (PQconsumeInput(conn) == 0 ||
+					PQstatus(conn) == CONNECTION_BAD)
+				{
+					(void) pgcopy_log_error(pgsql, NULL,
+											"connection was lost during pipeline sync");
+					pgsql_finish(pgsql);
+					return false;
+				}
 
-				continue;
+				if (PQisBusy(conn) == 0)
+				{
+					continue; /* more results buffered, keep consuming */
+				}
+				break; /* no more buffered; wait for server in outer loop */
 			}
 
 			results++;
@@ -2459,6 +2474,92 @@ pgsql_state_is_connection_error(PGSQL *pgsql)
 	return pgsql->connection != NULL &&
 		   (PQstatus(pgsql->connection) == CONNECTION_BAD ||
 			SQLSTATE_IS_CONNECTION_EXCEPTION(pgsql));
+}
+
+
+/*
+ * pgsql_is_permissions_error returns true when the last error on this
+ * connection was an authorization or privilege failure. These errors should
+ * not be retried — they require manual intervention (e.g. migration user
+ * was revoked).
+ *
+ * SQLSTATE class 28 = invalid_authorization_specification
+ * SQLSTATE 42501   = insufficient_privilege
+ */
+bool
+pgsql_is_permissions_error(PGSQL *pgsql)
+{
+	return (pgsql->sqlstate[0] == '2' && pgsql->sqlstate[1] == '8') ||
+		   strncmp(pgsql->sqlstate, "42501", 5) == 0;
+}
+
+
+/*
+ * pgsql_is_origin_in_use_error returns true when the last error was
+ * SQLSTATE 55006 (object_in_use), which occurs when another backend
+ * already holds the replication origin session. This is retriable: the
+ * caller should terminate the blocking backend and retry.
+ */
+bool
+pgsql_is_origin_in_use_error(PGSQL *pgsql)
+{
+	return strncmp(pgsql->sqlstate, "55006", 5) == 0;
+}
+
+
+/*
+ * pgsql_terminate_origin_holder terminates the backend that holds the
+ * replication origin session. The holder PID is extracted from the 55006
+ * error message on applyConn — PostgreSQL includes it verbatim:
+ * "replication origin with ID N is already active for PID N".
+ * This works on all PostgreSQL versions that support replication origins.
+ */
+bool
+pgsql_terminate_origin_holder(PGSQL *pgsql, PGSQL *applyConn,
+							  const char *nodeName)
+{
+	const char *errMsg = PQerrorMessage(applyConn->connection);
+	const char *marker = (errMsg != NULL) ? strstr(errMsg, "active for PID ") : NULL;
+
+	if (marker == NULL)
+	{
+		log_warn("Cannot identify backend holding replication origin \"%s\": "
+				 "PID not found in error message",
+				 nodeName);
+		return false;
+	}
+
+	char *endptr = NULL;
+	long holderPid = strtol(marker + strlen("active for PID "), &endptr, 10);
+
+	if (holderPid <= 0 || endptr == marker + strlen("active for PID "))
+	{
+		log_warn("Cannot identify backend holding replication origin \"%s\": "
+				 "parsed PID %ld is invalid",
+				 nodeName, holderPid);
+		return false;
+	}
+
+	log_info("Terminating PID %ld holding replication origin \"%s\"",
+			 holderPid, nodeName);
+
+	const char *sql = "SELECT pg_terminate_backend($1)";
+	int paramCount = 1;
+	Oid paramTypes[1] = { INT4OID };
+	char pidStr[12];
+	sformat(pidStr, sizeof(pidStr), "%ld", holderPid);
+	const char *paramValues[1] = { pidStr };
+
+	if (!pgsql_execute_with_params(pgsql, sql,
+								   paramCount, paramTypes, paramValues,
+								   NULL, NULL))
+	{
+		log_warn("Failed to terminate PID %ld holding replication origin \"%s\"",
+				 holderPid, nodeName);
+		return false;
+	}
+
+	return true;
 }
 
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -257,6 +257,9 @@ int pgsql_compute_connection_retry_sleep_time(ConnectionRetryPolicy *retryPolicy
 bool pgsql_retry_policy_expired(ConnectionRetryPolicy *retryPolicy);
 
 bool pgsql_state_is_connection_error(PGSQL *pgsql);
+bool pgsql_is_permissions_error(PGSQL *pgsql);
+bool pgsql_is_origin_in_use_error(PGSQL *pgsql);
+bool pgsql_terminate_origin_holder(PGSQL *pgsql, PGSQL *applyConn, const char *nodeName);
 
 void pgsql_finish(PGSQL *pgsql);
 void parseSingleValueResult(void *ctx, PGresult *result);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
 all: pagila pagila-multi-steps blobs unit filtering filtering-standby extensions \
 	 cdc-wal2json cdc-test-decoding cdc-endpos-between-transaction cdc-low-level \
-	 follow-wal2json follow-standby follow-9.6 follow-data-only \
+	 follow-wal2json follow-standby follow-9.6 follow-data-only follow-target-reconnect \
 	 endpos-in-multi-wal-txn exclude-extension \
 	 blob-snapshot-release follow-defer-indexes fk-not-valid;
 
@@ -64,6 +64,9 @@ follow-9.6: build
 follow-data-only: build
 	$(MAKE) -C $@
 
+follow-target-reconnect: build
+	$(MAKE) -C $@
+
 endpos-in-multi-wal-txn: build
 	$(MAKE) -C $@
 
@@ -89,6 +92,6 @@ build:
 .PHONY: all build
 .PHONY: pagila pagila-multi-steps blobs unit filtering filtering-standby extensions
 .PHONY: cdc-wal2json cdc-test-decoding cdc-low-level
-.PHONY: follow-wal2json follow-standby follow-9.6
+.PHONY: follow-wal2json follow-standby follow-9.6 follow-target-reconnect
 .PHONY: endpos-in-multi-wal-txn exclude-extension
 .PHONY: blob-snapshot-release follow-defer-indexes fk-not-valid

--- a/tests/follow-target-reconnect/Dockerfile
+++ b/tests/follow-target-reconnect/Dockerfile
@@ -1,0 +1,9 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./dml.sql dml.sql
+COPY ./ddl.sql ddl.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/follow-target-reconnect/Dockerfile.inject
+++ b/tests/follow-target-reconnect/Dockerfile.inject
@@ -1,0 +1,14 @@
+FROM pgcopydb
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/pgcopydb
+COPY ./inject.sh inject.sh
+COPY ./dml.sql dml.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/inject.sh"]

--- a/tests/follow-target-reconnect/Dockerfile.netblock
+++ b/tests/follow-target-reconnect/Dockerfile.netblock
@@ -1,0 +1,10 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iptables \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY netblock.sh /netblock.sh
+RUN chmod +x /netblock.sh
+
+CMD ["/netblock.sh"]

--- a/tests/follow-target-reconnect/Dockerfile.pg
+++ b/tests/follow-target-reconnect/Dockerfile.pg
@@ -1,0 +1,9 @@
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}
+
+ARG PGVERSION=16
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
+    && rm -rf /var/lib/apt/lists/*
+USER postgres

--- a/tests/follow-target-reconnect/Makefile
+++ b/tests/follow-target-reconnect/Makefile
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	$(DOCKER) compose up $(COMPOSE_EXIT)
+
+run: build fix-volumes
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+VPATH   = /var/run/pgcopydb
+CNAME   = follow-target-reconnect
+VNAME   = follow-target-reconnect
+VOLUMES = -v $(VNAME):$(VPATH)
+OPTS    = --env-file=../paths.env $(VOLUMES)
+CLEANUP = make -f /var/lib/postgres/cleanup.mk
+
+fix-volumes:
+	$(DOCKER) run --rm $(OPTS) $(CNAME) $(CLEANUP)
+
+attach:
+	$(DOCKER) run --rm -it $(OPTS) $(CNAME) bash
+
+.PHONY: run down build test fix-volumes

--- a/tests/follow-target-reconnect/compose.yaml
+++ b/tests/follow-target-reconnect/compose.yaml
@@ -1,0 +1,75 @@
+services:
+  source:
+    image: postgres-wal2json:${PGVERSION:-16}-bullseye
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+    expose:
+      - 5432
+    env_file:
+      - ../postgres.env
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    env_file:
+      - ../postgres.env
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  netblock:
+    build:
+      context: .
+      dockerfile: Dockerfile.netblock
+    network_mode: "service:target"
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - follow-target-reconnect:/var/run/pgcopydb
+    depends_on:
+      - target
+
+  inject:
+    build:
+      context: .
+      dockerfile: Dockerfile.inject
+    user: "0"
+    env_file:
+      - ../uris.env
+      - ../paths.env
+    volumes:
+      - follow-target-reconnect:/var/run/pgcopydb
+    depends_on:
+      - netblock
+
+  test:
+    image: follow-target-reconnect
+    build: .
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    environment:
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+    env_file:
+      - ../uris.env
+      - ../paths.env
+    # share TMPDIR between inject and test services
+    volumes:
+      - follow-target-reconnect:/var/run/pgcopydb
+    depends_on:
+      - source
+      - target
+      - inject
+
+volumes:
+  follow-target-reconnect:
+    external: true

--- a/tests/follow-target-reconnect/copydb.sh
+++ b/tests/follow-target-reconnect/copydb.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+
+# alter the pagila schema to allow capturing DDLs without pkey
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# pgcopydb clone uses the environment variables
+pgcopydb clone --follow --plugin wal2json
+
+# cleanup
+pgcopydb stream sentinel get
+
+# make sure the inject service has had time to see the final sentinel values
+sleep 2
+pgcopydb stream cleanup

--- a/tests/follow-target-reconnect/ddl.sql
+++ b/tests/follow-target-reconnect/ddl.sql
@@ -1,0 +1,14 @@
+---
+--- pgcopydb test/cdc/ddl.sql
+---
+--- This file implements DDL changes in the pagila database.
+
+begin;
+alter table payment_p2022_01 replica identity full;
+alter table payment_p2022_02 replica identity full;
+alter table payment_p2022_03 replica identity full;
+alter table payment_p2022_04 replica identity full;
+alter table payment_p2022_05 replica identity full;
+alter table payment_p2022_06 replica identity full;
+alter table payment_p2022_07 replica identity full;
+commit;

--- a/tests/follow-target-reconnect/dml.sql
+++ b/tests/follow-target-reconnect/dml.sql
@@ -1,0 +1,50 @@
+---
+--- pgcopydb test/cdc/dml.sql
+---
+--- This file implements DML changes in the pagila database.
+
+\set customerid1 291
+\set customerid2 292
+
+\set staffid1 1
+\set staffid2 2
+
+\set inventoryid1 371
+\set inventoryid2 1097
+
+begin;
+
+with r as
+ (
+   insert into rental(rental_date, inventory_id, customer_id, staff_id, last_update)
+        select '2022-06-01', :inventoryid1, :customerid1, :staffid1, '2022-06-01'
+     returning rental_id, customer_id, staff_id
+ )
+ insert into payment(customer_id, staff_id, rental_id, amount, payment_date)
+      select customer_id, staff_id, rental_id, 5.99, '2022-06-01'
+        from r;
+
+commit;
+
+-- update 10 rows in a single UPDATE command
+update public.payment set amount = 11.95 where amount = 11.99;
+
+begin;
+
+delete from payment
+      using rental
+      where rental.rental_id = payment.rental_id
+        and rental.last_update = '2022-06-01';
+
+delete from rental where rental.last_update = '2022-06-01';
+
+commit;
+
+--
+-- update the payments back to their original values
+--
+begin;
+
+update public.payment set amount = 11.99 where amount = 11.95;
+
+commit;

--- a/tests/follow-target-reconnect/inject.sh
+++ b/tests/follow-target-reconnect/inject.sh
@@ -1,0 +1,155 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+pgcopydb ping
+
+#
+# Only start injecting DML traffic on the source database when the pagila
+# schema and base data set has been deployed already. Our proxy to know that
+# that's the case is the existence of the pgcopydb.sentinel table on the
+# source database.
+#
+dbfile=${TMPDIR}/pgcopydb/schema/source.db
+
+deadline=$(($(date +%s) + 120))
+until [ -s ${dbfile} ]
+do
+    if [ $(date +%s) -gt ${deadline} ]; then
+        echo "TIMEOUT: pgcopydb did not initialize within 120s"
+        exit 1
+    fi
+    sleep 1
+done
+
+#
+# Inject 2 rounds of DML with WAL switches to generate CDC traffic before
+# simulating the connection failure.
+#
+for i in `seq 2`
+do
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 1
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 1
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_switch_wal()'
+    sleep 1
+done
+
+#
+# Wait for CDC follow mode to be actively streaming to the target before
+# simulating the failure. A non-zero flush_lsn means pgcopydb has begun
+# applying changes to the target.
+#
+flushlsn="0/0"
+
+deadline=$(($(date +%s) + 120))
+until [ "${flushlsn}" != "0/0" ]
+do
+    if [ $(date +%s) -gt ${deadline} ]; then
+        echo "TIMEOUT: pgcopydb CDC did not start streaming within 120s"
+        exit 1
+    fi
+    flushlsn=$(pgcopydb stream sentinel get --flush-lsn 2>/dev/null || echo "0/0")
+    sleep 2
+done
+
+#
+# Simulate a connection failure by triggering the netblock sidecar, which
+# shares the target's network namespace and inserts an iptables REJECT rule
+# for port 5432. This sends an immediate TCP RST so pgcopydb detects the
+# failure in milliseconds rather than waiting ~340 s for TCP retransmit.
+#
+# Signal the sidecar via a trigger file on the shared volume; it blocks for
+# 15 s, removes the rule, then writes a done file.
+#
+# Clean up any stale signal files from previous runs before triggering.
+rm -f /var/run/pgcopydb/block_target /var/run/pgcopydb/target_unblocked
+touch /var/run/pgcopydb/block_target
+
+deadline=$(($(date +%s) + 60))
+until [ -f /var/run/pgcopydb/target_unblocked ]
+do
+    if [ $(date +%s) -gt ${deadline} ]; then
+        echo "TIMEOUT: netblock sidecar did not complete within 60s"
+        exit 1
+    fi
+    sleep 0.5
+done
+
+rm -f /var/run/pgcopydb/target_unblocked
+
+# Target is accessible again since postgres never stopped.
+deadline=$(($(date +%s) + 30))
+until psql -d ${PGCOPYDB_TARGET_PGURI} -c "SELECT 1" >/dev/null 2>&1
+do
+    if [ $(date +%s) -gt ${deadline} ]; then
+        echo "TIMEOUT: target did not become reachable within 30s after unblock"
+        exit 1
+    fi
+    sleep 1
+done
+
+#
+# Inject 2 more rounds of DML after the reconnect to verify that changes
+# applied after the outage are also captured and replayed correctly.
+#
+for i in `seq 2`
+do
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 1
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+    sleep 1
+
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_switch_wal()'
+    sleep 1
+done
+
+# grab the current LSN, it's going to be our streaming end position
+lsn=`psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_flush_lsn()'`
+
+pgcopydb stream sentinel set endpos --current --debug
+pgcopydb stream sentinel get
+
+endpos=`pgcopydb stream sentinel get --endpos 2>/dev/null`
+
+if [ ${endpos} = "0/0" ]
+then
+    echo "expected ${lsn} endpos, found ${endpos}"
+    exit 1
+fi
+
+#
+# Because we're using docker-compose --abort-on-container-exit make sure
+# that the other process in the pgcopydb service is done before exiting
+# here.
+#
+flushlsn="0/0"
+
+deadline=$(($(date +%s) + 120))
+while [ ${flushlsn} \< ${endpos} ]
+do
+    if [ $(date +%s) -gt ${deadline} ]; then
+        echo "TIMEOUT: pgcopydb did not reach endpos ${endpos} within 120s (at ${flushlsn})"
+        exit 1
+    fi
+    flushlsn=`pgcopydb stream sentinel get --flush-lsn 2>/dev/null`
+    sleep 1
+done
+
+#
+# Still give some time to the pgcopydb service to finish its processing,
+# with the cleanup and all.
+#
+sleep 5

--- a/tests/follow-target-reconnect/netblock.sh
+++ b/tests/follow-target-reconnect/netblock.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+#
+# Runs as a sidecar sharing the target container's network namespace.
+# Waits for a trigger file written by inject.sh, then blocks port 5432
+# with iptables REJECT for 8 seconds before restoring access.
+#
+set -e
+
+TRIGGER=/var/run/pgcopydb/block_target
+DONE=/var/run/pgcopydb/target_unblocked
+
+until [ -f "$TRIGGER" ]
+do
+    sleep 0.5
+done
+
+rm -f "$TRIGGER"
+
+iptables -I INPUT -p tcp --dport 5432 -j REJECT --reject-with tcp-reset
+
+sleep 15
+
+iptables -D INPUT -p tcp --dport 5432 -j REJECT --reject-with tcp-reset
+
+touch "$DONE"

--- a/tests/run-parallel.sh
+++ b/tests/run-parallel.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+#
+# Runs the pgcopydb test suite locally in parallel, mirroring the
+# GitHub Actions tiered flow (run-tests-tiered.yml).
+#
+# Usage:
+#   PGVERSION=18 DOCKER=podman bash tests/run-parallel.sh
+#   JOBS=6 PGVERSION=18 DOCKER=podman bash tests/run-parallel.sh
+#
+# Environment:
+#   PGVERSION  - Postgres version to test against (default: 18)
+#   DOCKER     - Container runtime: docker or podman (default: auto-detect)
+#   JOBS       - Max parallel test jobs (default: 4)
+#   TIMEOUT    - Seconds per test before kill (default: 300, matching CI)
+
+set -euo pipefail
+
+PGVERSION=${PGVERSION:-18}
+DOCKER=${DOCKER:-$(command -v podman 2>/dev/null || command -v docker 2>/dev/null)}
+JOBS=${JOBS:-4}
+TIMEOUT=${TIMEOUT:-300}
+
+export PGVERSION DOCKER
+
+# Change to repo root regardless of where script is invoked from
+cd "$(dirname "$0")/.."
+
+LOGDIR=$(mktemp -d /tmp/pgcopydb-tests-XXXXXX)
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+# macOS ships without timeout; use gtimeout (brew install coreutils) if available
+TIMEOUT_CMD=$(command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || echo "")
+if [ -z "${TIMEOUT_CMD}" ]; then
+    log "WARNING: no timeout command found — tests will not be killed on hang"
+    run_with_timeout() { "$@"; }
+else
+    run_with_timeout() { "${TIMEOUT_CMD}" "${TIMEOUT}" "$@"; }
+fi
+export -f run_with_timeout
+export TIMEOUT_CMD
+
+# ── Tier 2: Smoke tests (run first, fast) ────────────────────────────────────
+TIER2=(unit)
+# tests/ci is just banned.h.sh - not container-based, skip for now
+
+# ── Tier 3: Integration tests (same matrix as GH Actions) ───────────────────
+TIER3=(
+    pagila
+    pagila-multi-steps
+    pagila-standby
+    blobs
+    filtering
+    filtering-standby
+    extensions
+    timescaledb
+    skip-publications
+    skip-vacuum
+    skip-large-objects
+    cdc-low-level
+    cdc-test-decoding
+    cdc-endpos-between-transaction
+    cdc-filtering
+    cdc-wal2json
+    follow-wal2json
+    follow-standby
+    follow-9.6
+    follow-data-only
+    follow-target-reconnect
+    endpos-in-multi-wal-txn
+    blob-snapshot-release
+    follow-defer-indexes
+)
+
+run_test() {
+    local test=$1
+    local logfile="${LOGDIR}/${test}.log"
+    local result="${LOGDIR}/${test}.result"
+
+    # Pre-create volume for tests that declare it external: true
+    ${DOCKER} volume create "${test}" >/dev/null 2>&1 || true
+
+    log "START: ${test}"
+    if run_with_timeout make "tests/${test}" >"${logfile}" 2>&1; then
+        echo PASS > "${result}"
+        log "PASS:  ${test}"
+    else
+        local code=$?
+        if [ "${code}" -eq 124 ]; then
+            echo TIMEOUT > "${result}"
+            log "TIMEOUT: ${test} (>${TIMEOUT}s) — see ${logfile}"
+        else
+            echo FAIL > "${result}"
+            log "FAIL:  ${test} — see ${logfile}"
+        fi
+    fi
+}
+export -f run_test log
+export LOGDIR TIMEOUT DOCKER PGVERSION
+
+run_tier() {
+    local tier_name=$1
+    shift
+    local tests=("$@")
+    local pids=()
+    local slot=0
+
+    log "=== ${tier_name}: ${#tests[@]} tests, ${JOBS} parallel slots ==="
+
+    for test in "${tests[@]}"; do
+        # Skip tests with no directory
+        if [ ! -d "tests/${test}" ]; then
+            log "SKIP:  ${test} (no directory)"
+            echo SKIP > "${LOGDIR}/${test}.result"
+            continue
+        fi
+
+        # Throttle to JOBS parallel slots
+        while [ "${#pids[@]}" -ge "${JOBS}" ]; do
+            local new_pids=()
+            for pid in "${pids[@]}"; do
+                if kill -0 "${pid}" 2>/dev/null; then
+                    new_pids+=("${pid}")
+                fi
+            done
+            pids=("${new_pids[@]+"${new_pids[@]}"}")
+            [ "${#pids[@]}" -ge "${JOBS}" ] && sleep 1
+        done
+
+        run_test "${test}" &
+        pids+=($!)
+    done
+
+    # Wait for remaining jobs
+    for pid in "${pids[@]+"${pids[@]}"}"; do
+        wait "${pid}" 2>/dev/null || true
+    done
+}
+
+# ── Build ────────────────────────────────────────────────────────────────────
+
+log "=== BUILD: pgcopydb image for PG${PGVERSION} ==="
+DOCKER=${DOCKER} PGVERSION=${PGVERSION} make build
+
+# ── Tier 2 ───────────────────────────────────────────────────────────────────
+
+run_tier "TIER 2 (smoke)" "${TIER2[@]}"
+
+tier2_failed=0
+for t in "${TIER2[@]}"; do
+    result=$(cat "${LOGDIR}/${t}.result" 2>/dev/null || echo MISSING)
+    [ "${result}" != "PASS" ] && [ "${result}" != "SKIP" ] && tier2_failed=1
+done
+
+if [ "${tier2_failed}" -eq 1 ]; then
+    log "=== TIER 2 FAILED — skipping integration tests ==="
+    # Mark all tier 3 tests as SKIP so they don't appear as FAIL in summary
+    for t in "${TIER3[@]}"; do
+        echo SKIP > "${LOGDIR}/${t}.result"
+    done
+else
+    # ── Tier 3 ───────────────────────────────────────────────────────────────
+    run_tier "TIER 3 (integration)" "${TIER3[@]}"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+pass=(); fail=(); timeout=(); skip=()
+all_tests=("${TIER2[@]}" "${TIER3[@]}")
+
+for t in "${all_tests[@]}"; do
+    result=$(cat "${LOGDIR}/${t}.result" 2>/dev/null || echo MISSING)
+    case "${result}" in
+        PASS)    pass+=("${t}") ;;
+        FAIL)    fail+=("${t}") ;;
+        TIMEOUT) timeout+=("${t}") ;;
+        SKIP)    skip+=("${t}") ;;
+        *)       fail+=("${t}") ;;
+    esac
+done
+
+echo ""
+echo "══════════════════════════════════════════════════"
+echo " Results: PG${PGVERSION}"
+echo "══════════════════════════════════════════════════"
+printf " PASS:    %d\n" "${#pass[@]}"
+printf " FAIL:    %d\n" "${#fail[@]}"
+printf " TIMEOUT: %d\n" "${#timeout[@]}"
+printf " SKIP:    %d\n" "${#skip[@]}"
+echo "──────────────────────────────────────────────────"
+
+for t in "${fail[@]+"${fail[@]}"}"; do
+    printf " FAIL:    %s\n" "${t}"
+    printf "          log: %s/%s.log\n" "${LOGDIR}" "${t}"
+done
+for t in "${timeout[@]+"${timeout[@]}"}"; do
+    printf " TIMEOUT: %s\n" "${t}"
+    printf "          log: %s/%s.log\n" "${LOGDIR}" "${t}"
+done
+
+echo "══════════════════════════════════════════════════"
+
+[ "${#fail[@]}" -eq 0 ] && [ "${#timeout[@]}" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds retry-with-backoff to the `--follow` (CDC) pipeline so a dropped **target** connection no longer fails the migration. When the apply/replay side loses its connection to the target mid-follow, it now reconnects with exponential backoff and resumes streaming, instead of terminating the clone.

Includes several correctness fixes uncovered while building the reconnect path:
- Fix a pipeline spin loop and a stale replication-origin session on reconnect.
- Fix replication-origin holder termination (parse the holder PID from the error message).
- Connection-retry helpers in `pgsql.c`/`pgsql.h`; reconnect/backoff loop in `ld_replay.c`; supporting changes in `ld_stream.c`, `ld_apply.c`, `follow.c`.

## Test plan

- New `follow-target-reconnect` suite: drives a follow migration, severs the target connection mid-stream via a netblock container, and asserts the pipeline reconnects and completes. Added to the Tier-3 CI matrix.
- `PGVERSION=16 make build` — clean (compiles against the current FK/defer-index CDC code).
- `PGVERSION=16 make tests` — full suite green on PG16, including `follow-target-reconnect`.

## Note (out of scope)

While validating, observed that `blob-snapshot-release` has a **pre-existing, intermittent** snapshot-release race on `main` (the source snapshot can be released before a COPY worker runs `SET TRANSACTION SNAPSHOT`, giving `ERROR: invalid snapshot identifier`). Measured ~1-in-5 on clean `main` without this change, so it is unrelated to this PR — flagging it as a separate issue to track.
