### PR TITLE
tests: add apt retries to pagila Dockerfile

### DIFF
--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -8,6 +8,8 @@ FROM debian:bookworm-slim
 
 ARG PGVERSION
 
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
Add `Acquire::Retries "3"` to the pagila test image so its build tolerates transient apt mirror failures.

Brings the file in sync with the dev tree (the only remaining test-infra difference between the two).

Validation: `PGVERSION=16 make build` clean; `make tests/pagila` green on PG16.