### PR TITLE
Release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+### pgcopydb v0.19.1 ###
+
+Patch release on top of v0.19 with fixes for CDC data fidelity, follow-mode
+shutdown, and foreign-key handling on partitioned schemas.
+
+### Fixed
+
+* Partitioned-table foreign keys: pgcopydb no longer lists Postgres's internal
+  per-partition FK clones (`pg_constraint.conparentid <> 0`) when creating
+  constraints directly. Recreating the top-level constraint already cascades to
+  every partition, so the clones only produced a flood of
+  `constraint "..." already exists` errors (and, for FKs referencing a
+  partitioned table, bogus single-partition constraints). The filter is
+  version-gated — `conparentid` exists only on PostgreSQL 11+ — and disabled
+  under `--defer-validate-fks`, which relies on the per-partition constraints on
+  PostgreSQL versions that reject `NOT VALID` on a partitioned parent
+* CDC float8 replay: floating-point values are now formatted with their
+  shortest round-trip representation, fixing precision loss that could break
+  numeric `WHERE`-clause matching during change apply and silently diverge
+  target data from the source
+* Follow mode: the CDC pipeline now shuts down cleanly when it reaches the
+  configured end position, and sequences are reset on the target at follow
+  completion so post-cutover writes receive correct sequence values
+
 ### pgcopydb v0.19 ###
 
 Builds on v0.18 with a focus on foreign-key constraint handling for


### PR DESCRIPTION
Patch release on top of v0.19. Covers everything merged to `main` since the v0.19.0 tag.

### Fixed
- **Partitioned-table foreign keys** (#41): stop listing Postgres's internal per-partition FK clones (`conparentid <> 0`) when creating constraints directly — recreating the top-level FK already cascades to every partition, so the clones only produced a flood of `constraint "..." already exists` errors (and bogus single-partition FKs when referencing a partitioned table). Version-gated (PG 11+) and disabled under `--defer-validate-fks`, which relies on those clones on PG versions that reject `NOT VALID` on a partitioned parent.
- **CDC float8 replay** (#39): format floating-point values with their shortest round-trip representation, fixing precision loss that could break numeric `WHERE`-clause matching during apply and silently diverge target data.
- **Follow mode** (#40): shut the CDC pipeline down cleanly at the configured end position, and reset sequences on the target at follow completion.

After merge: tag the merge commit `v0.19.1` (annotated) and push it to trigger the multi-arch docker publish.