### PR TITLE
Use (catoid, oid) object identity for filter lookups

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -381,12 +381,18 @@ static char *filterDBcreateDDLs[] = {
 	"create index s_d_refobjid on s_depend(refobjid)",
 	"create index s_d_objid on s_depend(objid)",
 
-	/* the filter table is our hash-table */
-	"create table filter(oid integer, restore_list_name text, kind text)",
-	"create unique index filter_oid on filter(oid) where oid > 0",
+	/* catalog namespace lookup: OIDs of system catalog tables, fetched at runtime */
+	"create table catnames(oid integer primary key, catname text unique)",
 
-	"create unique index filter_oid_rlname on filter(oid, restore_list_name) "
-	" where oid > 0",
+	/*
+	 * The filter table is our hash-table.  catoid mirrors pg_depend.classid:
+	 * it is the OID of the system catalog table that owns the object (e.g.
+	 * pg_class for tables/indexes/sequences, pg_constraint for constraints).
+	 * Using (catoid, oid) as the lookup key avoids false matches when OIDs
+	 * from different catalog namespaces happen to share the same numeric value.
+	 */
+	"create table filter(catoid integer, oid integer, restore_list_name text, kind text)",
+	"create unique index filter_catoid_oid on filter(catoid, oid) where oid > 0",
 
 	"create index filter_rlname on filter(restore_list_name)",
 
@@ -6264,6 +6270,134 @@ catalog_iter_s_seq_finish(SourceSeqIterator *iter)
 
 
 /*
+ * catalog_add_catname INSERTs a (oid, catname) row into the catnames table.
+ */
+bool
+catalog_add_catname(DatabaseCatalog *catalog, uint32_t oid, const char *catname)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_catname: db is NULL");
+		return false;
+	}
+
+	char *sql = "insert or ignore into catnames(oid, catname) values($1, $2)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "catname", 0, (char *) catname },
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+typedef struct CatNamesContext
+{
+	DatabaseCatalog *catalog;
+	bool parsedOk;
+} CatNamesContext;
+
+
+static void
+getCatNamesList(void *ctx, PGresult *result)
+{
+	CatNamesContext *context = (CatNamesContext *) ctx;
+	int nTuples = PQntuples(result);
+
+	if (PQnfields(result) != 2)
+	{
+		log_error("Query returned %d columns, expected 2", PQnfields(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	int errors = 0;
+
+	for (int rowNumber = 0; rowNumber < nTuples; rowNumber++)
+	{
+		uint32_t oid = 0;
+		char *value = PQgetvalue(result, rowNumber, 0);
+
+		if (!stringToUInt32(value, &oid) || oid == 0)
+		{
+			log_error("Invalid catalog OID \"%s\"", value);
+			++errors;
+			continue;
+		}
+
+		char *catname = PQgetvalue(result, rowNumber, 1);
+
+		if (!catalog_add_catname(context->catalog, oid, catname))
+		{
+			++errors;
+		}
+	}
+
+	context->parsedOk = (errors == 0);
+}
+
+
+/*
+ * catalog_fetch_catnames queries PostgreSQL for the OIDs of the system catalog
+ * tables that pgcopydb uses as filter namespace identifiers (catoid), then
+ * stores the (oid, catname) pairs in the catnames table of filterDB.
+ *
+ * This must be called before catalog_prepare_filter() so that the catnames
+ * subqueries inside the filter INSERT SQL resolve correctly.
+ */
+bool
+catalog_fetch_catnames(DatabaseCatalog *filterDB, PGSQL *pgsql)
+{
+	CatNamesContext context = { filterDB, false };
+
+	char *sql =
+		"  select c.oid, c.relname "
+		"    from pg_catalog.pg_class c "
+		"    join pg_catalog.pg_namespace n on n.oid = c.relnamespace "
+		"   where n.nspname = 'pg_catalog' "
+		"     and c.relname in ('pg_class', 'pg_constraint', 'pg_attrdef', "
+		"                       'pg_extension', 'pg_collation')";
+
+	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
+								   &context, &getCatNamesList))
+	{
+		log_error("Failed to fetch catalog namespace OIDs for filter catnames table");
+		return false;
+	}
+
+	if (!context.parsedOk)
+	{
+		log_error("Failed to fetch catalog namespace OIDs for filter catnames table");
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * catalog_prepare_filter prepares our filter Hash-Table, that used to be an
  * in-memory only thing, and now is a SQLite table with indexes, so that it can
  * spill to disk when we have giant database catalogs to take care of.
@@ -6284,9 +6418,10 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 	}
 
 	char *sql =
-		"insert into filter(oid, restore_list_name, kind) "
+		"insert into filter(catoid, oid, restore_list_name, kind) "
 
-		"     select oid, restore_list_name, 'table' "
+		"     select (select oid from catnames where catname = 'pg_class'),"
+		"            oid, restore_list_name, 'table' "
 		"       from s_table "
 
 		/*
@@ -6296,27 +6431,30 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 		 */
 		"  union all "
 
-		"	 select oid, restore_list_name, 'matview' "
+		"	 select (select oid from catnames where catname = 'pg_class'),"
+		"            oid, restore_list_name, 'matview' "
 		"	   from s_matview"
 
 		"  union all "
 
-		"     select oid, restore_list_name, 'index' "
+		"     select (select oid from catnames where catname = 'pg_class'),"
+		"            oid, restore_list_name, 'index' "
 		"       from s_index "
 
 		"  union all "
 
 		/* at the moment we lack restore names for constraints */
-		"     select oid, NULL as restore_list_name, 'constraint' "
+		"     select (select oid from catnames where catname = 'pg_constraint'),"
+		"            oid, NULL as restore_list_name, 'constraint' "
 		"       from s_constraint "
 
 		/*
 		 * Filtering-out sequences works with the following 3 Archive Catalog
 		 * entry kinds:
 		 *
-		 *  - SEQUENCE, matched by sequence oid
+		 *  - SEQUENCE, matched by sequence oid (pg_class namespace)
 		 *  - SEQUENCE OWNED BY, matched by sequence restore name
-		 *  - DEFAULT, matched by attribute oid
+		 *  - DEFAULT, matched by attroid (pg_attrdef namespace)
 		 *
 		 * In some cases we want to create the sequence, but we might want to
 		 * skip the SEQUENCE OWNED BY statement, because we didn't actually
@@ -6335,7 +6473,9 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 		 * still create it and refrain to add the sequence Oid to our hash
 		 * table here.
 		 */
-		"     select distinct s.oid, NULL as restore_list_name, 'sequence' "
+		"     select distinct "
+		"            (select oid from catnames where catname = 'pg_class'),"
+		"            s.oid, NULL as restore_list_name, 'sequence' "
 		"       from s_seq s "
 		"      where not exists"
 		"            (select 1 from source.s_seq ss where ss.oid = s.oid)"
@@ -6346,7 +6486,8 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 		 */
 		"  union all "
 
-		"     select NULL as oid, restore_list_name, 'sequence owned by' "
+		"     select (select oid from catnames where catname = 'pg_class'),"
+		"            NULL as oid, restore_list_name, 'sequence owned by' "
 		"       from ( "
 		"              select distinct s.restore_list_name "
 		"                from s_seq s "
@@ -6361,13 +6502,16 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 		"            ) as seqownedby "
 
 		/*
-		 * Also add pg_attribute.oid when it's not null (non-zero here). This
-		 * takes care of the DEFAULT entries in the pg_dump Archive Catalog,
-		 * and these entries target the attroid directly.
+		 * Also add attroid when it's not null (non-zero here). This takes care
+		 * of the DEFAULT entries in the pg_dump Archive Catalog; pg_dump emits
+		 * the pg_attrdef OID as the catalogId for these entries, so we store
+		 * attroid under the pg_attrdef catalog namespace.
 		 */
 		"  union all "
 
-		"     select distinct s.attroid, s.restore_list_name, 'default' "
+		"     select distinct "
+		"            (select oid from catnames where catname = 'pg_attrdef'),"
+		"            s.attroid, s.restore_list_name, 'default' "
 		"       from s_seq s "
 		"      where s.attroid > 0";
 
@@ -6400,15 +6544,15 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 
 	char *s_depend_sql =
 		hasExtensionFilters ?
-		"insert or ignore into filter(oid, restore_list_name, kind) "
-		"     select distinct objid, identity as restore_list_name, 'pg_depend' "
+		"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+		"     select distinct classid, objid, identity as restore_list_name, 'pg_depend' "
 		"       from s_depend d "
 		"      where not exists"
 		"            (select 1 from source.s_seq ss where ss.oid = d.objid) "
 		"        and d.deptype != 'e' "  /* Exclude extension dependencies */
 		:
-		"insert or ignore into filter(oid, restore_list_name, kind) "
-		"     select distinct objid, identity as restore_list_name, 'pg_depend' "
+		"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+		"     select distinct classid, objid, identity as restore_list_name, 'pg_depend' "
 		"       from s_depend d "
 		"      where not exists"
 		"            (select 1 from source.s_seq ss where ss.oid = d.objid) ";
@@ -6432,8 +6576,9 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 	if (skipExtensions)
 	{
 		char *s_extension_sql =
-			"insert or ignore into filter(oid, restore_list_name, kind) "
-			"     select oid, extname, 'extension' "
+			"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+			"     select (select oid from catnames where catname = 'pg_extension'),"
+			"            oid, extname, 'extension' "
 			"       from s_extension ";
 
 		if (!catalog_sql_prepare(db, s_extension_sql, &query))
@@ -6459,8 +6604,9 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 				SourceFilterExtension *ext = &filters->excludeExtensionList.array[i];
 
 				char *filter_ext_sql =
-					"insert or ignore into filter(oid, restore_list_name, kind) "
-					"     select oid, extname, 'extension' "
+					"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+					"     select (select oid from catnames where catname = 'pg_extension'),"
+					"            oid, extname, 'extension' "
 					"       from s_extension "
 					"      where extname = $1";
 
@@ -6516,8 +6662,9 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 			char include_ext_sql[BUFSIZE] = { 0 };
 
 			sformat(include_ext_sql, sizeof(include_ext_sql),
-					"insert or ignore into filter(oid, restore_list_name, kind) "
-					"     select oid, extname, 'extension' "
+					"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+					"     select (select oid from catnames where catname = 'pg_extension'),"
+					"            oid, extname, 'extension' "
 					"       from s_extension "
 					"      where extname not in (%s)", extlist);
 
@@ -6548,8 +6695,8 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 			filters->includeOnlyExtensionList.count > 0)
 		{
 			char *filter_extension_objects_sql =
-				"INSERT OR IGNORE INTO filter(oid, restore_list_name, kind) "
-				"SELECT DISTINCT d.objid, d.identity, 'extension-object' "
+				"INSERT OR IGNORE INTO filter(catoid, oid, restore_list_name, kind) "
+				"SELECT DISTINCT d.classid, d.objid, d.identity, 'extension-object' "
 				"FROM s_depend d "
 				"WHERE d.refobjid IN (SELECT oid FROM filter WHERE kind = 'extension') "
 				"  AND d.deptype = 'e'";
@@ -6578,7 +6725,8 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 				"SELECT DISTINCT t.nspname, t.relname "
 				"FROM filter f "
 				"JOIN s_table t ON f.oid = t.oid "
-				"WHERE f.kind = 'extension-object'";
+				"WHERE f.kind = 'extension-object' "
+				"  AND f.catoid = (SELECT oid FROM catnames WHERE catname = 'pg_class')";
 
 			if (!catalog_sql_prepare(db, query_filtered_tables_sql, &query))
 			{
@@ -6710,8 +6858,9 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 	if (skipCollations)
 	{
 		char *s_coll_sql =
-			"insert or ignore into filter(oid, restore_list_name, kind) "
-			"    select oid, restore_list_name, 'coll' "
+			"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+			"    select (select oid from catnames where catname = 'pg_collation'),"
+			"           oid, restore_list_name, 'coll' "
 			"      from s_coll ";
 
 		if (!catalog_sql_prepare(db, s_coll_sql, &query))
@@ -6740,12 +6889,15 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 
 
 /*
- * catalog_lookup_filter_by_oid fetches a  entry from our catalogs.
+ * catalog_lookup_filter_by_oid fetches a filter entry from our catalogs using
+ * the (catoid, objectOid) key that mirrors PostgreSQL's own (classid, objid)
+ * object identity from pg_depend.
  */
 bool
 catalog_lookup_filter_by_oid(DatabaseCatalog *catalog,
 							 CatalogFilter *result,
-							 uint32_t oid)
+							 uint32_t catalogOid,
+							 uint32_t objectOid)
 {
 	sqlite3 *db = catalog->db;
 
@@ -6756,7 +6908,78 @@ catalog_lookup_filter_by_oid(DatabaseCatalog *catalog,
 	}
 
 	char *sql =
-		"  select oid, restore_list_name, kind "
+		"  select catoid, oid, restore_list_name, kind "
+		"    from filter "
+		"   where catoid = $1 and oid = $2 ";
+
+	SQLiteQuery query = {
+		.context = result,
+		.fetchFunction = &catalog_filter_fetch
+	};
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[2] = {
+		{ BIND_PARAMETER_TYPE_INT64, "catoid", catalogOid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "oid", objectOid, NULL },
+	};
+
+	if (!catalog_sql_bind(&query, params, 2))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_filter_by_oid_only fetches a filter entry using the objectOid
+ * alone, without a catoid constraint. Used for pg_dump TOC entries that have
+ * catalogId.tableoid == 0 (such as REFRESH MATERIALIZED VIEW), where the
+ * (catoid, oid) pair is not available. PostgreSQL draws OIDs from a single
+ * counter per database, so any objectOid is unique across all system catalogs
+ * within that database, making an OID-only lookup safe in this case.
+ */
+bool
+catalog_lookup_filter_by_oid_only(DatabaseCatalog *catalog,
+								  CatalogFilter *result,
+								  uint32_t objectOid)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_filter_by_oid_only: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select catoid, oid, restore_list_name, kind "
 		"    from filter "
 		"   where oid = $1 ";
 
@@ -6780,7 +7003,7 @@ catalog_lookup_filter_by_oid(DatabaseCatalog *catalog,
 
 	/* bind our parameters now */
 	BindParam params[1] = {
-		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "oid", objectOid, NULL },
 	};
 
 	if (!catalog_sql_bind(&query, params, 1))
@@ -6830,7 +7053,7 @@ catalog_lookup_filter_by_rlname(DatabaseCatalog *catalog,
 	 * SQLite error condition about "another row available".
 	 */
 	char *sql =
-		"  select oid, restore_list_name, kind "
+		"  select catoid, oid, restore_list_name, kind "
 		"    from filter "
 		"   where restore_list_name = $1 "
 		"   limit 1";
@@ -6882,7 +7105,7 @@ catalog_lookup_filter_by_rlname(DatabaseCatalog *catalog,
 
 /*
  * catalog_filter_fetch fetches a CatalogFilter entry from a SQLite ppStmt
- * result set.
+ * result set.  Column layout: 0=catoid, 1=oid, 2=restore_list_name, 3=kind.
  */
 bool
 catalog_filter_fetch(SQLiteQuery *query)
@@ -6892,17 +7115,18 @@ catalog_filter_fetch(SQLiteQuery *query)
 	/* cleanup the memory area before re-use */
 	bzero(entry, sizeof(CatalogFilter));
 
-	entry->oid = sqlite3_column_int64(query->ppStmt, 0);
+	entry->catoid = sqlite3_column_int64(query->ppStmt, 0);
+	entry->oid = sqlite3_column_int64(query->ppStmt, 1);
 
-	if (sqlite3_column_type(query->ppStmt, 1) != SQLITE_NULL)
+	if (sqlite3_column_type(query->ppStmt, 2) != SQLITE_NULL)
 	{
 		strlcpy(entry->restoreListName,
-				(char *) sqlite3_column_text(query->ppStmt, 1),
+				(char *) sqlite3_column_text(query->ppStmt, 2),
 				sizeof(entry->restoreListName));
 	}
 
 	strlcpy(entry->kind,
-			(char *) sqlite3_column_text(query->ppStmt, 2),
+			(char *) sqlite3_column_text(query->ppStmt, 3),
 			sizeof(entry->kind));
 
 	return true;

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -493,10 +493,15 @@ bool catalog_iter_s_seq_finish(SourceSeqIterator *iter);
 bool catalog_s_seq_fetch(SQLiteQuery *query);
 
 /*
- * Filtering is done through a single table that concatenates the Oid and
- * pg_restore archives TOC list names (restore_list_name) in such a way that we
- * can get away with a single hash-table like lookup.
+ * Filtering is done through a single table keyed by (catoid, oid) — the same
+ * object identity scheme PostgreSQL uses in pg_depend (classid + objid).
+ * catoid is the OID of the system catalog table that owns the object, fetched
+ * at runtime via catalog_fetch_catnames().
  */
+bool catalog_fetch_catnames(DatabaseCatalog *filterDB, PGSQL *pgsql);
+bool catalog_add_catname(DatabaseCatalog *catalog, uint32_t oid,
+						 const char *catname);
+
 bool catalog_prepare_filter(DatabaseCatalog *catalog,
 							bool skipExtensions,
 							bool skipCollations,
@@ -505,6 +510,7 @@ bool catalog_prepare_filter(DatabaseCatalog *catalog,
 
 typedef struct CatalogFilter
 {
+	uint32_t catoid;
 	uint32_t oid;
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 	char kind[PG_NAMEDATALEN];
@@ -512,7 +518,12 @@ typedef struct CatalogFilter
 
 bool catalog_lookup_filter_by_oid(DatabaseCatalog *catalog,
 								  CatalogFilter *result,
-								  uint32_t oid);
+								  uint32_t catalogOid,
+								  uint32_t objectOid);
+
+bool catalog_lookup_filter_by_oid_only(DatabaseCatalog *catalog,
+									   CatalogFilter *result,
+									   uint32_t objectOid);
 
 bool catalog_lookup_filter_by_rlname(DatabaseCatalog *catalog,
 									 CatalogFilter *result,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -414,6 +414,7 @@ bool copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql, bool reset
 /* copydb_schema.c */
 bool copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs);
 bool copydb_objectid_is_filtered_out(CopyDataSpec *specs,
+									 uint32_t catalogOid,
 									 uint32_t oid,
 									 char *restoreListName);
 bool copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs,

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1082,6 +1082,7 @@ copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs, uint32_t oid)
  */
 bool
 copydb_objectid_is_filtered_out(CopyDataSpec *specs,
+								uint32_t catalogOid,
 								uint32_t oid,
 								char *restoreListName)
 {
@@ -1090,10 +1091,29 @@ copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 
 	if (oid != 0)
 	{
-		if (!catalog_lookup_filter_by_oid(filtersDB, &result, oid))
+		if (catalogOid != 0)
 		{
-			/* errors have already been logged */
-			return false;
+			if (!catalog_lookup_filter_by_oid(filtersDB, &result,
+											  catalogOid, oid))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+		}
+		else
+		{
+			/*
+			 * Some TOC entries (e.g. REFRESH MATERIALIZED VIEW) carry
+			 * catalogId.tableoid == 0 in the pg_dump format, so we have no
+			 * catoid to disambiguate. Fall back to an OID-only lookup;
+			 * PostgreSQL OIDs are drawn from a single counter per database,
+			 * so any objectOid is unique across all system catalogs.
+			 */
+			if (!catalog_lookup_filter_by_oid_only(filtersDB, &result, oid))
+			{
+				/* errors have already been logged */
+				return false;
+			}
 		}
 
 		if (result.oid != 0)
@@ -1251,6 +1271,13 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 			};
 
 			(void) catalog_start_timing(&timing);
+
+			if (!catalog_fetch_catnames(filtersDB, pgsql))
+			{
+				/* errors have already been logged */
+				(void) semaphore_unlock(&(filtersDB->sema));
+				return false;
+			}
 
 			if (!catalog_prepare_filter(filtersDB,
 										specs->skipExtensions,
@@ -1450,6 +1477,13 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 		};
 
 		(void) catalog_start_timing(&timing);
+
+		if (!catalog_fetch_catnames(filtersDB, pgsql))
+		{
+			/* errors have already been logged */
+			(void) semaphore_unlock(&(filtersDB->sema));
+			return false;
+		}
 
 		if (!catalog_prepare_filter(filtersDB,
 									specs->skipExtensions,

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -907,7 +907,8 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 				   item->restoreListName);
 	}
 
-	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name))
+	if (!skip &&
+		copydb_objectid_is_filtered_out(specs, item->catalogOid, oid, name))
 	{
 		skip = true;
 

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -235,7 +235,8 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 	{
 		CatalogFilter filter = { 0 };
 
-		if (catalog_lookup_filter_by_oid(context->filtersDB, &filter, ext->oid))
+		if (catalog_lookup_filter_by_oid_only(context->filtersDB, &filter,
+											  ext->oid))
 		{
 			/* Extension is filtered, skip it */
 			return true;


### PR DESCRIPTION
### Problem

The `filter` table keyed rows on `oid` alone, with a UNIQUE index on `(oid)`. PostgreSQL OIDs are unique only *within* a system catalog, not across them, so a `pg_type` OID can equal a `pg_proc` OID. When that happens, a lookup for one object matches the other's filter row and the wrong object is skipped.

Observed in a migration: a `CREATE TYPE` was silently dropped because its enum OID matched an excluded extension function's `pg_proc` OID, after which the dependent `CREATE TABLE` failed `type ... does not exist` and the clone aborted (exit 12).

### Fix

Mirror `pg_depend`'s `(classid, objid)` identity model:

- `filter` gains a `catoid` column; the unique index becomes `(catoid, oid)`.
- A `catnames` table maps the relevant catalog OIDs (`pg_class`, `pg_constraint`, `pg_attrdef`, `pg_extension`, `pg_collation`), fetched from Postgres at runtime — nothing hardcoded.
- Lookups take `(catalogOid, objectOid)`. TOC entries that carry no catalog id (e.g. `REFRESH MATERIALIZED VIEW`) fall back to an OID-only lookup, which is safe because OIDs are drawn from a single per-database counter.

Ports upstream `dimitri/pgcopydb` #972, reconciled with this repo's fork-only filter code:

- `copydb_objectid_is_filtered_out` takes a `catalogOid` (threaded from the archive item) rather than upstream's `item` struct.
- The fork-only `extension`, `extension-object`, and `pg_depend` filter inserts carry `catoid` (`classid`, or the `pg_extension`/`pg_class` `catnames` entry).
- The `extension-object` → `s_table` query-back join is guarded by the `pg_class` catoid (it was an OID-only match, the same collision class this fix addresses).

### Tests

Upstream ships no regression test for this, and a true cross-catalog OID collision can't be reproduced deterministically (OIDs are PG-assigned). Coverage relies on the existing filter/extension suites for no-regression.

Verified locally: full `PGVERSION=18 make tests` green; `exclude-extension`, `filtering`, and `extensions` explicitly exercise the changed paths.