### PR TITLE
Fix list table-parts always reporting 0 parts

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1370,6 +1370,89 @@ cli_list_table_parts(int argc, char **argv)
 		exit(EXIT_CODE_QUIT);
 	}
 
+	/*
+	 * Check whether the parts section was already cached from a previous run.
+	 * If so, re-use the catalog rows directly; otherwise compute them now and
+	 * store them so the next call is instant.
+	 */
+	CatalogSection partsSection = {
+		.section = DATA_SECTION_TABLE_DATA_PARTS
+	};
+
+	if (!catalog_section_state(sourceDB, &partsSection))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!partsSection.fetched)
+	{
+		PGSQL pgsql = { 0 };
+		ConnStrings *dsn = &(listDBoptions.connStrings);
+
+		if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_SOURCE);
+		}
+
+		/*
+		 * For CTID-based splits we need fresh relpages from pg_class.
+		 * Run ANALYZE first (unless the user asked for estimates only) so that
+		 * the page count reflects the current table size.
+		 */
+		if (streq(table->partKey, "ctid"))
+		{
+			if (!copySpecs.estimateTableSizes)
+			{
+				char sql[BUFSIZE] = { 0 };
+
+				sformat(sql, sizeof(sql), "ANALYZE %s", table->qname);
+				log_notice("%s", sql);
+
+				if (!pgsql_execute(&pgsql, sql))
+				{
+					log_error("Failed to refresh table %s statistics",
+							  table->qname);
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+			}
+
+			if (!schema_list_relpages(&pgsql, table, sourceDB))
+			{
+				log_error("Failed to fetch table %s relpages", table->qname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+		}
+
+		TopLevelTiming timing = {
+			.label = CopyDataSectionToString(DATA_SECTION_TABLE_DATA_PARTS)
+		};
+
+		(void) catalog_start_timing(&timing);
+
+		if (!schema_list_partitions(&pgsql,
+									sourceDB,
+									table,
+									listDBoptions.splitTablesLargerThan.bytes,
+									listDBoptions.splitMaxParts))
+		{
+			log_error("Failed to compute partitions for table %s",
+					  table->qname);
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		(void) catalog_stop_timing(&timing);
+
+		if (!catalog_register_section(sourceDB, &timing))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		pgsql_finish(&pgsql);
+	}
+
 	log_info("Table %s COPY will be split %d-ways",
 			 table->qname,
 			 table->partition.partCount);


### PR DESCRIPTION
### Problem
`pgcopydb list table-parts` always printed "Table … COPY will be split 0-ways" with an empty table, regardless of size or `--split-tables-larger-than`.

### Root cause
`cli_list_table_parts` set `partKey` (including the CTID case) but never called `schema_list_partitions`, so the `s_table_part` catalog was empty and `table->partition.partCount` was 0. The full copy path (`copydb_prepare_table_specs_hook`) does call it; the list command bypassed it.

### Fix
Compute the partitions (`schema_list_partitions`) before the display loop, so the command reports the real split. `list table-parts` is a diagnostic/planning command — no effect on the migration path.

Clean cherry-pick of upstream `dimitri/pgcopydb` #982.

### Tests
`unit` suite (which drives `list table-parts`) green in the full `PGVERSION=18 make tests` run. The only red was the pre-existing `blob-snapshot-release` snapshot-race flake, which touches no code in this change.