### PR TITLE
Restore role ownership when copying LOBs for PG>=17

### DIFF
--- a/src/bin/pgcopydb/blobs.c
+++ b/src/bin/pgcopydb/blobs.c
@@ -21,6 +21,7 @@ typedef struct BlobMetadataArray
 {
 	int count;
 	Oid oids[MAX_BLOB_PER_FETCH];
+	char rolnames[MAX_BLOB_PER_FETCH][PG_NAMEDATALEN];
 } BlobMetadataArray;
 
 typedef struct BlobMetadataArrayContext
@@ -441,12 +442,14 @@ copydb_blob_worker(CopyDataSpec *specs)
 
 				if (!pg_copy_large_object(src, &dst,
 										  dropIfExists,
-										  mesg.data.oid,
+										  !specs->restoreOptions.noOwner,
+										  mesg.data.lo.oid,
+										  mesg.data.lo.rolname,
 										  &bytesTransmitted))
 				{
 					log_error("Failed to copy Large Object with oid %u, "
 							  "see above for details",
-							  mesg.data.oid);
+							  mesg.data.lo.oid);
 					return false;
 				}
 
@@ -511,12 +514,12 @@ copydb_blob_worker(CopyDataSpec *specs)
  * given blob.
  */
 bool
-copydb_add_blob(CopyDataSpec *specs, uint32_t oid)
+copydb_add_blob(CopyDataSpec *specs, uint32_t oid, const char *rolname)
 {
-	QMessage mesg = {
-		.type = QMSG_TYPE_BLOBOID,
-		.data.oid = oid
-	};
+	QMessage mesg = { .type = QMSG_TYPE_BLOBOID };
+
+	mesg.data.lo.oid = oid;
+	strlcpy(mesg.data.lo.rolname, rolname, sizeof(mesg.data.lo.rolname));
 
 	log_debug("copydb_add_blob(%d): %u", specs->loQueue.qId, oid);
 
@@ -592,7 +595,8 @@ copydb_queue_largeobject_metadata(CopyDataSpec *specs, uint64_t *count)
 	BlobMetadataArrayContext context = { 0 };
 	char *sql =
 		"DECLARE bloboid CURSOR FOR "
-		"SELECT oid FROM pg_largeobject_metadata ORDER BY 1";
+		"SELECT oid, format('%I', pg_catalog.pg_get_userbyid(lomowner)) "
+		"FROM pg_largeobject_metadata ORDER BY 1";
 
 	if (!pgsql_execute(src, sql))
 	{
@@ -633,7 +637,7 @@ copydb_queue_largeobject_metadata(CopyDataSpec *specs, uint64_t *count)
 		{
 			Oid blobOid = context.array.oids[i];
 
-			if (!copydb_add_blob(specs, blobOid))
+			if (!copydb_add_blob(specs, blobOid, context.array.rolnames[i]))
 			{
 				log_error("Failed to queue Large Object %u, "
 						  "see above for details",
@@ -665,9 +669,9 @@ parseBlobMetadataArray(void *ctx, PGresult *result)
 {
 	BlobMetadataArrayContext *context = (BlobMetadataArrayContext *) ctx;
 
-	if (PQnfields(result) != 1)
+	if (PQnfields(result) != 2)
 	{
-		log_error("Query returned %d columns, expected 1", PQnfields(result));
+		log_error("Query returned %d columns, expected 2", PQnfields(result));
 		context->parsedOk = false;
 		return;
 	}
@@ -685,5 +689,10 @@ parseBlobMetadataArray(void *ctx, PGresult *result)
 			context->parsedOk = false;
 			return;
 		}
+
+		char *rolname = PQgetvalue(result, i, 1);
+
+		strlcpy(context->array.rolnames[i], rolname,
+				sizeof(context->array.rolnames[i]));
 	}
 }

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -478,7 +478,7 @@ bool copydb_blob_supervisor(CopyDataSpec *specs);
 bool copydb_start_blob_workers(CopyDataSpec *specs);
 bool copydb_blob_worker(CopyDataSpec *specs);
 bool copydb_queue_largeobject_metadata(CopyDataSpec *specs, uint64_t *count);
-bool copydb_add_blob(CopyDataSpec *specs, uint32_t oid);
+bool copydb_add_blob(CopyDataSpec *specs, uint32_t oid, const char *rolname);
 bool copydb_send_lo_stop(CopyDataSpec *specs);
 
 /* vacuum.c */

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3468,12 +3468,21 @@ pgsql_set_gucs(PGSQL *pgsql, GUC *settings)
  * pg_copy_large_object copies given large object found on the src database
  * into the dst database. The copy includes re-using the same OID for the large
  * objects on both sides.
+ *
+ * When restoreOwner is true and rolname is a non-empty (already quoted)
+ * identifier, the large object ownership is also restored on the target. This
+ * is only necessary on the PG17+ path where pgcopydb creates the large object
+ * itself via lo_create(): the object is then owned by the connecting role,
+ * whereas on PG16 and earlier the pre-data restore recreates it with the
+ * original owner. See the version split documented below.
  */
 bool
 pg_copy_large_object(PGSQL *src,
 					 PGSQL *dst,
 					 bool dropIfExists,
+					 bool restoreOwner,
 					 uint32_t blobOid,
+					 const char *rolname,
 					 uint64_t *bytesTransmitted)
 {
 	log_debug("Copying large object %u", blobOid);
@@ -3694,6 +3703,43 @@ pg_copy_large_object(PGSQL *src,
 
 	lo_close(src->connection, srcfd);
 	lo_close(dst->connection, dstfd);
+
+	/*
+	 * 5. Restore the large object ownership on the target.
+	 *
+	 *    Only needed when we created the object ourselves above (needsCreate),
+	 *    via lo_create(): it is then owned by the connecting role. That happens
+	 *    on PG17+ (pre-data no longer includes large object metadata) and after
+	 *    dropIfExists. When the pre-data restore already recreated the object
+	 *    with its original owner there is nothing to do, and we skip the ALTER
+	 *    to avoid a needless round-trip per large object.
+	 *
+	 *    rolname is already a quoted identifier (format('%I', ...) computed on
+	 *    the source); an empty string means the owner could not be determined,
+	 *    in which case we leave the object owned by the connecting role rather
+	 *    than emit invalid SQL.
+	 */
+	if (needsCreate && restoreOwner && rolname != NULL && rolname[0] != '\0')
+	{
+		char sql[BUFSIZE] = { 0 };
+
+		sformat(sql, sizeof(sql),
+				"ALTER LARGE OBJECT %u OWNER TO %s",
+				blobOid,
+				rolname);
+
+		if (!pgsql_execute(dst, sql))
+		{
+			log_error("Failed to set owner of large object %u to %s",
+					  blobOid,
+					  rolname);
+
+			pgsql_finish(src);
+			pgsql_finish(dst);
+
+			return false;
+		}
+	}
 
 	return true;
 }

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -364,7 +364,9 @@ bool pgsql_set_gucs(PGSQL *pgsql, GUC *settings);
 bool pg_copy_large_object(PGSQL *src,
 						  PGSQL *dst,
 						  bool dropIfExists,
+						  bool restoreOwner,
 						  uint32_t oid,
+						  const char *rolname,
 						  uint64_t *bytesTransmitted);
 
 /*

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -14,6 +14,8 @@
 
 #include "postgres.h"
 
+#include "pg_utils.h"
+
 typedef struct Queue
 {
 	char *name;
@@ -52,6 +54,13 @@ typedef struct QMessage
 			uint32_t oid;
 			uint32_t part;
 		} tp;
+
+		/* large objects: oid and owner role (for QMSG_TYPE_BLOBOID) */
+		struct lo
+		{
+			uint32_t oid;
+			char rolname[PG_NAMEDATALEN]; /* format('%I', ...); "" when unknown */
+		} lo;
 	} data;
 } QMessage;
 

--- a/tests/blobs/copydb.sh
+++ b/tests/blobs/copydb.sh
@@ -16,12 +16,21 @@ export PAGER=cat
 # make sure source and target databases are ready
 pgcopydb ping
 
+# import.sql reassigns one large object to a dedicated, non-connecting role to
+# exercise ownership preservation.  The role must exist on both ends: pgcopydb
+# does not copy roles as part of `dump schema` / `restore pre-data`, so we
+# create it explicitly on each side (this mirrors real deployments where the
+# owner role is provisioned on the target cluster ahead of the migration).
+psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -c "create role blobowner with login;"
+psql -d ${PGCOPYDB_TARGET_PGURI} -1 -c "create role blobowner with login;"
+
 psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/import.sql
 
 # Save info of blobs on the source to compare against the target after migration
 # for validation. We are doing this because we are going to insert some blobs
-# after taking snapshot and ensure we don't migrate them.
-SQL="select loid, count(data) as parts, sum(length(data)) as size from pg_largeobject group by loid order by loid;"
+# after taking snapshot and ensure we don't migrate them. The owner column also
+# proves pg_largeobject_metadata.lomowner is carried across (see import.sql).
+SQL="select m.oid, pg_catalog.pg_get_userbyid(m.lomowner) as owner, count(l.data) as parts, sum(length(l.data)) as size from pg_largeobject_metadata m join pg_largeobject l on l.loid = m.oid group by m.oid, m.lomowner order by m.oid;"
 
 psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -c "${SQL}" > /tmp/source.lo
 

--- a/tests/blobs/import.sql
+++ b/tests/blobs/import.sql
@@ -4,3 +4,17 @@
 \lo_import 'imgs/nam-anh-QJbyG6O0ick-unsplash.jpg'
 \lo_import 'imgs/redcharlie-Y--zr3CPaPs-unsplash.jpg'
 \lo_import 'imgs/richard-jacobs-8oenpCXktqQ-unsplash.jpg'
+
+-- Hand a single large object to a non-superuser role that is NOT the role
+-- pgcopydb connects as.  The other blobs stay owned by the connecting role
+-- (postgres), so the source has mixed ownership.  This proves pgcopydb carries
+-- pg_largeobject_metadata.lomowner across per-blob: the reassigned object must
+-- come back owned by blobowner and the rest must stay owned by postgres.
+DO $$
+DECLARE
+    loid oid;
+BEGIN
+    SELECT min(oid) INTO loid FROM pg_largeobject_metadata;
+    EXECUTE format('ALTER LARGE OBJECT %s OWNER TO blobowner', loid);
+END
+$$;


### PR DESCRIPTION
### Problem
On PostgreSQL 17+, `pg_dump` no longer includes large object metadata in the pre-data section, so pgcopydb creates each large object itself via `lo_create()`. That leaves the object **owned by the connecting role** rather than its original owner. (Fixes upstream issue #1027.)

### Fix (ports upstream dimitri/pgcopydb #1026)
After copying the object contents, run `ALTER LARGE OBJECT … OWNER TO <owner>` when an owner is known, restoring the original ownership.

**PS adaptation:** upstream gates this on a `dstIsPG17orLater` flag that doesn't exist in this repo. This repo already tracks whether it created the object itself via the `needsCreate` existence check — which is the precise signal (and also covers the `dropIfExists` path) — so the restore is gated on `needsCreate` instead of a raw version check.

### Tests
Full `PGVERSION=18 make tests` green (all suites, exit 0). The `blobs` suite (with a non-default `blobowner` role) exercises the ownership path; the cherry-pick brought its test updates.