### PR TITLE
Base CTID split part count on total size (heap + TOAST)

### DIFF
--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -234,6 +234,12 @@ partitioned (on the fly) and split between processes:
        COPY (SELECT * FROM source.table WHERE ctid >= '(17775,0)'::tid and ctid < '(23698,0)'::tid)
        COPY (SELECT * FROM source.table WHERE ctid >= '(23698,0)'::tid)
 
+    The number of CTID parts is derived from the total on-disk size of the
+    table (heap plus TOAST), so a table whose size is dominated by TOAST still
+    splits into a sensible number of concurrent COPY processes. A CTID range
+    scan detoasts each row it reads, so splitting the heap page range
+    parallelizes the TOAST reads as well.
+
 
   - To decide if a table COPY processing should be split, the command line
     option ``split-tables-larger-than`` is used, or the environment variable

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -4144,14 +4144,9 @@ schema_list_partitions(PGSQL *pgsql,
 		max = table->relpages;
 
 		/*
-		 * Base the CTID part count on the total on-disk size (heap + TOAST),
-		 * same as the key-based branch, so TOAST-dominant tables split. A CTID
-		 * range scan reads heap rows and detoasts each row on the fly, so
-		 * splitting the heap page range parallelizes the TOAST reads too.
-		 *
-		 * NOTE: relies on table->bytes being pg_table_size (TOAST-inclusive).
-		 * Under --estimate-table-sizes, bytes is a heap-only estimate and this
-		 * degrades to the previous heap-based behavior (acceptable).
+		 * Base the part count on total on-disk size (heap + TOAST) so
+		 * TOAST-dominant tables split. Under --estimate-table-sizes, bytes is
+		 * heap-only and this degrades to the prior heap-based behavior.
 		 */
 		partsCount = ceil((double) table->bytes / (double) partSize);
 

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -4144,26 +4144,33 @@ schema_list_partitions(PGSQL *pgsql,
 		max = table->relpages;
 
 		/*
-		 * Get the block size from the origin in the first attempt
-		 * and then memoize it.
+		 * Base the CTID part count on the total on-disk size (heap + TOAST),
+		 * same as the key-based branch, so TOAST-dominant tables split. A CTID
+		 * range scan reads heap rows and detoasts each row on the fly, so
+		 * splitting the heap page range parallelizes the TOAST reads too.
+		 *
+		 * NOTE: relies on table->bytes being pg_table_size (TOAST-inclusive).
+		 * Under --estimate-table-sizes, bytes is a heap-only estimate and this
+		 * degrades to the previous heap-based behavior (acceptable).
 		 */
-		static int blockSize = 0;
-		bool isBlockSizeCached = blockSize != 0;
-		if (!isBlockSizeCached && !pgsql_get_block_size(pgsql, &blockSize))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-		uint64_t pagesPerPart = ceil((double) partSize / blockSize);
-
-		partsCount = ceil((double) table->relpages / (double) pagesPerPart);
+		partsCount = ceil((double) table->bytes / (double) partSize);
 
 		if (splitMaxParts > 0 && partsCount > splitMaxParts)
 		{
 			partsCount = splitMaxParts;
 		}
 
-		partsSize = ceil((double) table->relpages / partsCount);
+		/* cannot create more CTID page-ranges than there are heap pages */
+		if (table->relpages > 0 && partsCount > table->relpages)
+		{
+			partsCount = table->relpages;
+		}
+		else if (table->relpages == 0)
+		{
+			partsCount = 1;
+		}
+
+		partsSize = ceil((double) table->relpages / (double) partsCount);
 	}
 
 	/*

--- a/tests/unit/expected/4-list-table-split.out
+++ b/tests/unit/expected/4-list-table-split.out
@@ -33,17 +33,24 @@
 024-05-23 09:14:52.903 184 INFO   main.c:136                Running pgcopydb version 0.15.28.g40af8d7 from "/usr/local/bin/pgcopydb"
 2024-05-23 09:14:52.941 184 INFO   copydb.c:105              Using work dir "/tmp/unit/split"
 2024-05-23 09:14:52.944 184 INFO   cli_list.c:1297           Table public.table_ctid_candidate is 152 kB large which is larger than --split-tables-larger-than 10 kB, and does not have a unique column of type integer: splitting by CTID
-2024-05-23 09:14:52.944 184 INFO   cli_list.c:1321           Table public.table_ctid_candidate COPY will be split 8-ways
+2024-05-23 09:14:52.944 184 INFO   cli_list.c:1321           Table public.table_ctid_candidate COPY will be split 15-ways
         Part |          Min |          Max |        Count
 -------------+--------------+--------------+-------------
-         1/8 |        (0,0) |        (1,0) |            2
-         2/8 |        (2,0) |        (3,0) |            2
-         3/8 |        (4,0) |        (5,0) |            2
-         4/8 |        (6,0) |        (7,0) |            2
-         5/8 |        (8,0) |        (9,0) |            2
-         6/8 |       (10,0) |       (11,0) |            2
-         7/8 |       (12,0) |       (13,0) |            2
-         8/8 |       (14,0) |       (-1,0) |           -1
+         1/15 |        (0,0) |        (0,0) |            1
+         2/15 |        (1,0) |        (1,0) |            1
+         3/15 |        (2,0) |        (2,0) |            1
+         4/15 |        (3,0) |        (3,0) |            1
+         5/15 |        (4,0) |        (4,0) |            1
+         6/15 |        (5,0) |        (5,0) |            1
+         7/15 |        (6,0) |        (6,0) |            1
+         8/15 |        (7,0) |        (7,0) |            1
+         9/15 |        (8,0) |        (8,0) |            1
+        10/15 |        (9,0) |        (9,0) |            1
+        11/15 |       (10,0) |       (10,0) |            1
+        12/15 |       (11,0) |       (11,0) |            1
+        13/15 |       (12,0) |       (12,0) |            1
+        14/15 |       (13,0) |       (13,0) |            1
+        15/15 |       (14,0) |       (-1,0) |           -1
 2024-05-23 11:01:25.505 201 INFO   main.c:136                Running pgcopydb version 0.15.28.g40af8d7 from "/usr/local/bin/pgcopydb"
 2024-05-23 11:01:25.551 201 INFO   cli_list.c:1300           Table public.table_ctid_candidate_skip is 152 kB large which is larger than --split-tables-larger-than 10 kB, does not have a unique column of type integer, and CTID split is disabled.Same table concurrency is not enabled
 
@@ -55,3 +62,9 @@
          1/3 |           -1 |           -1 |           -1
          2/3 |            1 |           34 |           34
          3/3 |           35 |           -1 |           -1
+20:54:39.774 91 INFO   Table public.table_toast_heavy is 6848 kB large which is larger than --split-tables-larger-than 1024 kB, and does not have a unique column of type integer: splitting by CTID
+20:54:39.774 91 INFO   Table public.table_toast_heavy COPY will be split 2-ways
+        Part |          Min |          Max |        Count
+-------------+--------------+--------------+-------------
+         1/2 |        (0,0) |        (1,0) |            2
+         2/2 |        (2,0) |       (-1,0) |           -1

--- a/tests/unit/script/4-list-table-split.sh
+++ b/tests/unit/script/4-list-table-split.sh
@@ -59,10 +59,8 @@ pgcopydb list table-parts --dir ${DIR} \
     --split-tables-larger-than "10 kB" --split-max-parts 3 2>&1
 
 
-# TOAST-heavy table (~6.5 MB, ~4 heap pages, no integer PK). With a 1 MB
-# threshold the OLD heap-only math gives ceil(4 / (1MB/8KB)) = 1 (no split);
-# the fix bases the part count on total size: ceil(6.5MB/1MB)=7, capped to
-# --split-max-parts 2 => 2 parts.
+# TOAST-heavy table (~6.5 MB, ~4 heap pages, no integer PK): old heap-only
+# math gives 1 part (no split); the fix splits on total size, capped to 2.
 DIR=/tmp/unit/toast-split
 pgcopydb list schema --dir ${DIR} --not-consistent \
     --split-tables-larger-than 1MB --split-max-parts 2 >/dev/null

--- a/tests/unit/script/4-list-table-split.sh
+++ b/tests/unit/script/4-list-table-split.sh
@@ -57,3 +57,16 @@ pgcopydb list schema --dir ${DIR} ${OPTS} >/dev/null
 pgcopydb list table-parts --dir ${DIR} \
     --schema-name "public" --table-name "table_1" \
     --split-tables-larger-than "10 kB" --split-max-parts 3 2>&1
+
+
+# TOAST-heavy table (~6.5 MB, ~4 heap pages, no integer PK). With a 1 MB
+# threshold the OLD heap-only math gives ceil(4 / (1MB/8KB)) = 1 (no split);
+# the fix bases the part count on total size: ceil(6.5MB/1MB)=7, capped to
+# --split-max-parts 2 => 2 parts.
+DIR=/tmp/unit/toast-split
+pgcopydb list schema --dir ${DIR} --not-consistent \
+    --split-tables-larger-than 1MB --split-max-parts 2 >/dev/null
+
+pgcopydb list table-parts --dir ${DIR} \
+    --schema-name "public" --table-name "table_toast_heavy" \
+    --split-tables-larger-than 1MB --split-max-parts 2 2>&1

--- a/tests/unit/setup/4-list-table-split.sql
+++ b/tests/unit/setup/4-list-table-split.sql
@@ -100,17 +100,15 @@ from
     table_ctid_candidate;
 
 -- TOAST-dominant table, no integer PK: tiny heap, large out-of-line TOAST.
--- Exercises CTID split part-count based on total size (heap + TOAST). With
--- STORAGE EXTERNAL, TOAST is not compressed, so the out-of-line size is stable
--- across PG 16/17/18. Physical shape: heap ~4 pages, TOAST ~6.4 MB,
--- pg_table_size ~6.5 MB.
+-- STORAGE EXTERNAL disables compression so the size is stable across PG
+-- versions (heap ~4 pages, pg_table_size ~6.5 MB).
 
 create table table_toast_heavy (
-    id integer,          -- no PK/unique index => CTID fallback
+    id integer,
     payload text
 );
 alter table table_toast_heavy alter column payload set storage external;
 
 insert into table_toast_heavy (id, payload)
-select g, repeat(md5(g::text), 400)   -- ~12.8 KB/row > 2KB => out-of-line TOAST
+select g, repeat(md5(g::text), 400)
 from generate_series(1, 500) g;

--- a/tests/unit/setup/4-list-table-split.sql
+++ b/tests/unit/setup/4-list-table-split.sql
@@ -98,3 +98,19 @@ select
     *
 from
     table_ctid_candidate;
+
+-- TOAST-dominant table, no integer PK: tiny heap, large out-of-line TOAST.
+-- Exercises CTID split part-count based on total size (heap + TOAST). With
+-- STORAGE EXTERNAL, TOAST is not compressed, so the out-of-line size is stable
+-- across PG 16/17/18. Physical shape: heap ~4 pages, TOAST ~6.4 MB,
+-- pg_table_size ~6.5 MB.
+
+create table table_toast_heavy (
+    id integer,          -- no PK/unique index => CTID fallback
+    payload text
+);
+alter table table_toast_heavy alter column payload set storage external;
+
+insert into table_toast_heavy (id, payload)
+select g, repeat(md5(g::text), 400)   -- ~12.8 KB/row > 2KB => out-of-line TOAST
+from generate_series(1, 500) g;


### PR DESCRIPTION
## Problem

A migration stalled on a single huge table: heap ~3.3 GiB, TOAST ~936 GiB (99% of a ~942 GiB total), with a `text` primary key. With `--split-tables-larger-than 50GB` the table became **one** COPY job that serially detoasted the entire ~936 GiB — extremely slow.

Two different size metrics were used in the split path:

1. **Split decision** compares `pg_table_size(oid)` (TOAST-inclusive) against the threshold, so the table is correctly chosen to be split.
2. **CTID fallback** is taken because a `text` (or `uuid`) PK is not a single-column integer unique/PK key.
3. **CTID part-count math** divided `relpages` (heap pages **only**, TOAST excluded) by pages-per-part. With a tiny heap relative to a huge TOAST, this rounds down to a single part.

So TOAST counted for *whether* to split but was invisible to *how many* CTID parts to make.

## Fix

Base the CTID part count on `table->bytes` (total on-disk size, heap + TOAST), matching the key-based branch, then:

- cap at `--split-max-parts`;
- cap at `relpages` (cannot create more CTID page-ranges than there are heap pages);
- distribute heap pages evenly across the parts.

A CTID range scan reads heap rows and detoasts each row on the fly, so splitting the heap page range parallelizes the TOAST reads. This also closes a latent case where `relpages == 0` produced zero partitions.

Under `--estimate-table-sizes`, `bytes` is a heap-only estimate, so the change degrades gracefully to the previous heap-based behavior (no regression there).

### Behavior change beyond TOAST-heavy tables

The CTID part count is now total-size-based for **every** CTID-split table, not only TOAST-dominant ones. For a plain table the total size ≈ heap size, so counts track the threshold more directly. This is reflected in the updated `table_ctid_candidate` grid in the unit test (splits into more parts than before for the same tiny test threshold).

## Testing

Added a regression test to the existing split suite (`tests/unit/4-list-table-split`):

- A physically TOAST-heavy table (`table_toast_heavy`) with no integer PK and `STORAGE EXTERNAL` (uncompressed → deterministic out-of-line size across PG 16/17/18): heap ~4 pages, TOAST ~6.4 MB.
- With a 1 MB threshold the old heap-only math gives 1 part (no split); the fix gives `ceil(6.5MB/1MB)=7`, capped by `--split-max-parts 2` to 2 parts. The pinned grid is verified identical on PG17 and PG18.

Pre-fix, the new assertion fails (the table reports a single part), proving it is a real regression test.

| Check | Result |
|-------|--------|
| `make build` (PG18) | clean |
| `make tests/unit` (PG18) | pass |
| `make tests/unit` (PG17) | pass — pinned grid identical |
| `citus_indent --check` | pass |
| `make tests` (full, PG18) | pass |

Docs: added a sentence to `docs/concurrency.rst` noting the CTID part count is derived from total on-disk size (heap + TOAST). No CLI/help changes, so no `docs/include/*.rst` regeneration.