### PR TITLE
Bound the libpq pipeline backlog with byte-based syncs

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -647,6 +647,9 @@ stream_apply_sql(StreamApplyContext *context,
 {
 	PGSQL *applyPgConn = &(context->applyPgConn);
 
+	/* bytes this line hands to libpq; branches that send nothing zero it */
+	uint64_t sentBytes = strlen(sql);
+
 	switch (metadata->action)
 	{
 		case STREAM_ACTION_SWITCH:
@@ -660,6 +663,7 @@ stream_apply_sql(StreamApplyContext *context,
 			 * .sql file to apply.
 			 */
 			context->switchLSN = metadata->lsn;
+			sentBytes = 0;
 
 			break;
 		}
@@ -1196,6 +1200,8 @@ stream_apply_sql(StreamApplyContext *context,
 				return true;
 			}
 
+			sentBytes = 0;
+
 			/* Only prepare if we haven't already */
 			if (stmt != NULL && !stmt->prepared)
 			{
@@ -1210,6 +1216,7 @@ stream_apply_sql(StreamApplyContext *context,
 				}
 
 				stmt->prepared = true;
+				sentBytes = strlen(metadata->stmt);
 			}
 
 			break;
@@ -1343,7 +1350,10 @@ stream_apply_sql(StreamApplyContext *context,
 	 * pipeline sync only fetches pending results, the explicit
 	 * BEGIN/COMMIT transaction is unaffected.
 	 */
-	context->pipelineBytes += strlen(sql) + PIPELINE_STMT_OVERHEAD;
+	if (sentBytes > 0)
+	{
+		context->pipelineBytes += sentBytes + PIPELINE_STMT_OVERHEAD;
+	}
 
 	if (context->pipelineBytes >= PIPELINE_BYTES_SYNC_THRESHOLD)
 	{

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -32,14 +32,14 @@
 #include "summary.h"
 
 /*
- * libpq's output buffer uses a signed int for its size, so it can only grow
- * to ~1 GB before the doubling arithmetic overflows.  When the CDC apply
- * pipelines many EXECUTE statements with large parameter values (e.g. rows
- * containing 300 MB email bodies), the accumulated data can exceed that
- * limit.  We force a pipeline sync at transaction boundaries once the
- * estimated parameter data reaches this threshold.
+ * libpq memmoves its whole outstanding buffer contents on every partial send
+ * and read, making apply quadratic in the pipeline backlog size.  Sync the
+ * pipeline every time this many bytes were sent, mid-transaction included.
  */
-#define PIPELINE_BYTES_SYNC_THRESHOLD (512ULL * 1024 * 1024)
+#define PIPELINE_BYTES_SYNC_THRESHOLD (1024 * 1024)
+
+/* per-statement allowance for protocol framing and result traffic */
+#define PIPELINE_STMT_OVERHEAD 64
 
 GUC applySettingsSync[] = {
 	COMMON_GUC_SETTINGS,
@@ -583,14 +583,9 @@ stream_apply_file(StreamApplyContext *context)
 
 		/*
 		 * Sync the pipeline at transaction boundaries (COMMIT or
-		 * KEEPALIVE) when either the 1-second timer has elapsed or
-		 * when accumulated parameter data approaches libpq's output
-		 * buffer limit.
-		 *
-		 * libpq's output buffer size is tracked with a signed int,
-		 * so the buffer can grow to ~1 GB before the doubling logic
-		 * overflows.  We sync well before that at 512 MB to leave
-		 * headroom for wire-protocol framing and PREPARE overhead.
+		 * KEEPALIVE) when the 1-second timer has elapsed, bounding
+		 * replay latency.  The byte-based sync that bounds the
+		 * pipeline backlog size lives in stream_apply_sql.
 		 */
 		if (metadata->action == STREAM_ACTION_COMMIT ||
 			metadata->action == STREAM_ACTION_KEEPALIVE)
@@ -598,10 +593,7 @@ stream_apply_file(StreamApplyContext *context)
 			bool timeToSync =
 				1 < (time(NULL) - context->applyPgConn.pipelineSyncTime);
 
-			bool bufferNearFull =
-				context->pipelineBytes >= PIPELINE_BYTES_SYNC_THRESHOLD;
-
-			if (timeToSync || bufferNearFull)
+			if (timeToSync)
 			{
 				/* fetch results until done */
 				if (!pgsql_sync_pipeline(&(context->applyPgConn)))
@@ -1294,40 +1286,6 @@ stream_apply_sql(StreamApplyContext *context,
 					/* errors have already been logged */
 					return false;
 				}
-
-				/*
-				 * Track accumulated parameter bytes in the pipeline.
-				 * libpq output buffer uses int (~1 GB effective max
-				 * due to doubling), force sync before overflow.
-				 */
-				for (int j = 0; j < count; j++)
-				{
-					if (paramValues[j] != NULL)
-					{
-						context->pipelineBytes += strlen(paramValues[j]);
-					}
-				}
-
-				/*
-				 * When a single transaction contains many large rows
-				 * (e.g. 330 MB email bodies), the pipeline buffer can
-				 * exceed libpq's ~1 GB limit before reaching COMMIT.
-				 * Sync mid-transaction to drain the buffer.  This is
-				 * safe: we use explicit BEGIN/COMMIT, so a pipeline
-				 * sync only flushes pending results without affecting
-				 * the transaction.
-				 */
-				if (context->pipelineBytes >= PIPELINE_BYTES_SYNC_THRESHOLD)
-				{
-					if (!pgsql_sync_pipeline(applyPgConn))
-					{
-						log_error("Failed to sync the pipeline, "
-								  "see previous error for details");
-						return false;
-					}
-
-					context->pipelineBytes = 0;
-				}
 			}
 
 
@@ -1377,6 +1335,26 @@ stream_apply_sql(StreamApplyContext *context,
 
 			return false;
 		}
+	}
+
+	/*
+	 * Sync the pipeline as soon as the data sent since the last sync
+	 * exceeds the threshold, even in the middle of a transaction: a
+	 * pipeline sync only fetches pending results, the explicit
+	 * BEGIN/COMMIT transaction is unaffected.
+	 */
+	context->pipelineBytes += strlen(sql) + PIPELINE_STMT_OVERHEAD;
+
+	if (context->pipelineBytes >= PIPELINE_BYTES_SYNC_THRESHOLD)
+	{
+		if (!pgsql_sync_pipeline(applyPgConn))
+		{
+			log_error("Failed to sync the pipeline, "
+					  "see previous error for details");
+			return false;
+		}
+
+		context->pipelineBytes = 0;
 	}
 
 	return true;

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -418,6 +418,8 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 							  "error for details");
 					return false;
 				}
+
+				context->pipelineBytes = 0;
 			}
 			break;
 		}
@@ -482,6 +484,8 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 					  "details");
 			return false;
 		}
+
+		context->pipelineBytes = 0;
 	}
 
 	return true;

--- a/tests/cdc-low-level/copydb.sh
+++ b/tests/cdc-low-level/copydb.sh
@@ -129,5 +129,34 @@ pgcopydb stream replay --resume --endpos "${lsn}"
 psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "select pg_replication_origin_advance('pgcopydb', '0/0');"
 pgcopydb stream apply /usr/src/pgcopydb/pipeline-deadlock.sql
 
+# bounded pipeline sync test: a single multi-MB transaction must trigger
+# byte-based pipeline syncs before its COMMIT, bounding libpq's buffers
+BOUNDED=/tmp/bounded-sync.sql
+
+awk 'BEGIN {
+  printf "BEGIN; -- {\"xid\":99000001,\"lsn\":\"E0/10000000\",\"timestamp\":\"2026-07-25 10:00:00.000000+0000\",\"commit_lsn\":\"E0/20000000\"}\n";
+  for (i = 1; i <= 25000; i++) {
+    printf "PREPARE ab12cd34 AS INSERT INTO \"public\".\"bounded_sync\" (\"id\", \"payload\") overriding system value VALUES ($1, $2);\n";
+    printf "EXECUTE ab12cd34[\"%d\",\"payload-%d-0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz\"];\n", i, i;
+  }
+  printf "COMMIT; -- {\"xid\":99000001,\"lsn\":\"E0/20000000\",\"timestamp\":\"2026-07-25 10:00:00.000000+0000\"}\n";
+  printf "-- SWITCH WAL {\"lsn\":\"E0/21000000\"}\n";
+}' > ${BOUNDED}
+
+psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "select pg_replication_origin_advance('pgcopydb', '0/0');"
+
+pgcopydb stream apply --trace ${BOUNDED} > /tmp/bounded-sync.log 2>&1 || \
+    { tail -50 /tmp/bounded-sync.log; exit 1; }
+
+syncs=$(grep -c "Start pipeline sync" /tmp/bounded-sync.log || true)
+rows=$(psql -At -d ${PGCOPYDB_TARGET_PGURI} -c "select count(*) from bounded_sync")
+
+echo "bounded sync test: ${syncs} pipeline syncs, ${rows} rows applied"
+
+test "${rows}" -eq 25000
+
+# unpatched pgcopydb only syncs at COMMIT/EOF, which fails this assertion
+test "${syncs}" -ge 5
+
 # cleanup
 pgcopydb stream cleanup --verbose

--- a/tests/cdc-low-level/ddl.sql
+++ b/tests/cdc-low-level/ddl.sql
@@ -37,4 +37,7 @@ EXECUTE FUNCTION notify_on_insert();
 -- Lets enable the trigger for the replica mode
 ALTER TABLE metrics ENABLE REPLICA TRIGGER insert_notice_trigger;
 
+-- bounded pipeline sync test table; keep trigger-free (no NOTICE traffic)
+create table bounded_sync(id int, payload text);
+
 commit;


### PR DESCRIPTION
## Problem

During a production CDC migration, apply fell behind the source and never converged: each 64 MiB WAL segment (~130 MB of transformed SQL, ~388k statements) took ~18 minutes to apply while the source produced one every ~13.6 minutes. `perf` on the apply process showed 99.3% of CPU inside `__memmove_avx512_unaligned_erms` with the call graph `stream_apply_file → pgsql_sync_pipeline → PQconsumeInput → memmove`, ~350 statements/s reaching the target (which was idle at 0.06 ms/statement), and apply RSS ballooned to 1.13 GB.

Apply pipelines every statement on a nonblocking connection and only drains the pipeline at COMMIT/KEEPALIVE boundaries behind a 1-second timer, or mid-transaction after 512 MB of accumulated EXECUTE *parameter* bytes. The timer bounds time, not bytes — the loop can enqueue tens of MB into libpq's buffers before the first sync fires — and the parameter-only 512 MB threshold effectively never triggers. libpq shifts the entire outstanding contents of its send/receive buffers with memmove on every partial send and read (`pqSendSome` / `pqReadData` in fe-misc.c), so per-statement cost grows with the backlog and applying a batch is quadratic in its size. At the observed ~65 MB mean backlog that is ~25 TB of memory traffic per 130 MB file: one core pinned at memory bandwidth.

## Fix

Count every applied statement's bytes (`strlen(sql)` plus a small framing allowance) and sync the pipeline each time 1 MB has been sent since the last sync, mid-transaction included. A pipeline sync only fetches pending results; the explicit BEGIN/COMMIT transaction is unaffected — the same argument as the existing 512 MB mid-transaction sync this replaces. The 1-second timer sync at transaction boundaries remains as the latency bound. The EXECUTE-parameter-only accounting is removed (parameters are part of the counted statement line), and the two replay-path sync sites that didn't reset the byte counter now do.

With the backlog capped at 1 MB, each libpq buffer shift is KB-scale and apply becomes target-bound instead of memmove-bound.

## Testing

New regression test in `tests/cdc-low-level`: generates a single-transaction, 25k-statement (~5.6 MB) .sql file, applies it with `--trace`, and asserts the full row count plus ≥5 pipeline syncs. Pre-fix the assertion fails with exactly 2 syncs (final COMMIT + end-of-file, zero mid-transaction); post-fix it passes with 9.

Benchmarks on a production-shaped fixture (85 MB, 420k lines, 35k transactions of ~10 statements), unpatched vs patched, same databases:

- wall clock: 64 s → 4 s; apply peak RSS 430 MB → 288 MB (the remainder is the whole-file buffer plus per-line metadata that file-mode apply always allocates)
- gdb stack-sampling during apply: 97% of samples executing memcpy under `PQconsumeInput` before; 0% after, with every sample idle in `select()` waiting on the target
- scaling 25k → 100k statements: 0.23 s → 2.71 s before (11.8×, super-linear); 0.20 s → 0.74 s after (3.7×, linear)

| Check | Result |
|-------|--------|
| `make build` (docker, PG16 image) | clean |
| `make tests/cdc-low-level` (includes new test) | pass |
| `make tests/cdc-endpos-between-transaction` | pass |
| `tests/cdc-filtering` (run directly, see note) | pass |
| `tests/cdc-message-handling` (run directly, see note) | pass |
| `ci/banned.h.sh` | pass |
| `citus_indent --check` | not run locally (tool unavailable); CI runs it |

Note: `make tests/cdc-filtering` is silently a no-op — including in CI — because the directory name shadows the missing make target, and `cdc-message-handling` is wired into neither `tests/Makefile` nor the CI matrix. Both suites were run directly here via `make -C tests/<dir> test DOCKER=docker`. Worth fixing in a separate PR.
