### PR TITLE
tests: pin pagila fixture to v3.1.0

### DIFF
--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -44,7 +44,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/
-RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
+# pinned: pagila v4.0.0 requires PG18 + pgvector; v3.1.0 loads on PG16/17/18
+RUN git clone --depth 1 --branch pagila-v3.1.0 https://github.com/devrimgunduz/pagila.git
 
 #RUN adduser --disabled-password --gecos '' --home /var/lib/postgres docker
 #RUN adduser docker sudo

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -44,8 +44,11 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/
-# pinned: pagila v4.0.0 requires PG18 + pgvector; v3.1.0 loads on PG16/17/18
-RUN git clone --depth 1 --branch pagila-v3.1.0 https://github.com/devrimgunduz/pagila.git
+# pinned to pagila v3.1.0 @ fef9675 (immutable SHA; v4 needs PG18 + pgvector)
+RUN git init -q pagila \
+  && git -C pagila remote add origin https://github.com/devrimgunduz/pagila.git \
+  && git -C pagila fetch -q --depth 1 origin fef9675714cfba1756df4719b5e36075a7ddf90e \
+  && git -C pagila checkout -q FETCH_HEAD
 
 #RUN adduser --disabled-password --gecos '' --home /var/lib/postgres docker
 #RUN adduser docker sudo


### PR DESCRIPTION
## Problem

`tests/Dockerfile.pagila` cloned the pagila fixture from upstream **HEAD, unpinned** (`git clone --depth 1`, no ref). pagila **v4.0.0** (2026-07-28) requires PostgreSQL 18 (`uuidv7()` column defaults) and the pgvector extension (`CREATE EXTENSION vector`), neither of which the PG16/17/18 test images provide. So a fresh image build began pulling that schema and broke **every pagila-based suite** (pagila, follow-*, cdc-*, extensions, filtering) at schema load, on all three PG versions — `ERROR: extension "vector" is not available`. It's unpinned-fixture drift, not a code regression; main would fail the same way on a fresh build.

There is also a supply-chain angle: the fixture is fetched from an external repo at build time and loaded into the test database via `psql -f`, which is code-execution-capable server-side. Fetching an unpinned/mutable ref means CI runs whatever that repo serves at build time.

## Fix

Pin pagila to the **immutable commit SHA** for v3.1.0 (`fef9675714cfba1756df4719b5e36075a7ddf90e`), the last pre-v4 release, which loads on PG16/17/18 with no extra extensions:

```
RUN git init -q pagila \
  && git -C pagila remote add origin https://github.com/devrimgunduz/pagila.git \
  && git -C pagila fetch -q --depth 1 origin fef9675714cfba1756df4719b5e36075a7ddf90e \
  && git -C pagila checkout -q FETCH_HEAD
```

SHA (not tag): git tags are mutable and could be re-pointed; the SHA fixes the exact bytes. Shallow fetch-by-SHA keeps the build fast.

## Testing

Fresh builds (the Dockerfile change invalidates the clone cache, so pagila is re-fetched at the pinned SHA):
- `make tests/pagila` on PG18 — pass
- `make tests/pagila` on PG17 — pass (with the tag; SHA points at the same commit)
- PG16 covered by CI

## Follow-ups (not in this PR)

- Optionally **vendor** `pagila-schema.sql` + `pagila-data.sql` in-tree (~3.1 MB total: 52 KB schema + 3.0 MB data) to eliminate the build-time external fetch entirely and put the content under review — strongest supply-chain posture.
- pagila was the only rolling-HEAD dependency. `postgres:${PGVERSION}` (test DB) tracks latest minor and is the next-highest-value pin; `debian:sid` in `Dockerfile.debian*` is rolling but packaging-QA only (off the CI path). GitHub Actions are already SHA-pinned.