### PR TITLE
Fix dangling pointers to `intToString()` temporaries

### DIFF
--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -543,8 +543,10 @@ pg_vacuumdb_analyze_only(PostgresPaths *pgPaths, ConnStrings *connStrings, int j
 
 	args[argsIndex++] = (char *) pgPaths->vacuumdb;
 	args[argsIndex++] = "--analyze-only";
+	IntString jobsString = intToString(jobs);
+
 	args[argsIndex++] = "--jobs";
-	args[argsIndex++] = intToString(jobs).strValue;
+	args[argsIndex++] = jobsString.strValue;
 	args[argsIndex++] = "--dbname";
 	args[argsIndex++] = (char *) connStrings->safeSourcePGURI.pguri;
 
@@ -627,8 +629,10 @@ pg_vacuumdb_analyze_only_target(PostgresPaths *pgPaths,
 
 	args[argsIndex++] = (char *) pgPaths->vacuumdb;
 	args[argsIndex++] = "--analyze-only";
+	IntString jobsString = intToString(jobs);
+
 	args[argsIndex++] = "--jobs";
-	args[argsIndex++] = intToString(jobs).strValue;
+	args[argsIndex++] = jobsString.strValue;
 	args[argsIndex++] = "--dbname";
 	args[argsIndex++] = (char *) connStrings->safeTargetPGURI.pguri;
 
@@ -1020,6 +1024,8 @@ pg_restore_db(PostgresPaths *pgPaths,
 	args[argsIndex++] = "--section";
 	args[argsIndex++] = (char *) sectionOption;
 
+	IntString jobsString = intToString(options.jobs);
+
 	if (options.jobs == 1)
 	{
 		args[argsIndex++] = "--single-transaction";
@@ -1027,7 +1033,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 	else
 	{
 		args[argsIndex++] = "--jobs";
-		args[argsIndex++] = intToString(options.jobs).strValue;
+		args[argsIndex++] = jobsString.strValue;
 	}
 
 	if (options.dropIfExists)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5257,7 +5257,9 @@ pgsql_table_exists(PGSQL *pgsql,
 	const Oid paramTypes[3] = { OIDOID, TEXTOID, TEXTOID };
 	const char *paramValues[3] = { 0 };
 
-	paramValues[0] = intToString(oid).strValue;
+	IntString oidString = intToString(oid);
+
+	paramValues[0] = oidString.strValue;
 	paramValues[1] = nspname;
 	paramValues[2] = relname;
 

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -2405,8 +2405,10 @@ schema_set_sequence_value(PGSQL *pgsql, SourceSequence *seq)
 	Oid paramTypes[3] = { TEXTOID, INT8OID, BOOLOID };
 	const char *paramValues[3];
 
+	IntString lastValueString = intToString(seq->lastValue);
+
 	paramValues[0] = seq->qname;
-	paramValues[1] = intToString(seq->lastValue).strValue;
+	paramValues[1] = lastValueString.strValue;
 	paramValues[2] = seq->isCalled ? "true" : "false";
 
 	if (!pgsql_execute_with_params(pgsql, sql,


### PR DESCRIPTION
`intToString()` returns an `IntString` by value, and several call sites took a pointer to its embedded `strValue` buffer directly off the temporary, whose lifetime ends at the end of the statement. On macOS/clang the dead stack memory is reused before the value is read, so `pg_restore` got `--jobs ''` and failed; same latent bug in vacuumdb --jobs, a table-exists query param, and sequence `setval()`.

Bind the result to a named local that outlives the pointer.