### PR TITLE
tests: ignore whitespace when diffing psql expanded output

### DIFF
--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -48,7 +48,9 @@ do
     e=./expected/${t}.out
     psql -d "${PGCOPYDB_TARGET_PGURI}" ${pgopts} --file ./sql/$t.sql &> $r
     test -f $e || cat $r
-    diff $e $r || exit 1
+    # ignore whitespace: since 18.6 psql widens expanded output rows to the
+    # record header width, and these tests assert content, not alignment
+    diff -w $e $r || exit 1
 done
 
 


### PR DESCRIPTION
## Problem

`tests/unit` fails on an unchanged tree. Current `main` reproduces it:

```
diff ./expected/3-string-escape.out /tmp/results/3-string-escape.out
3c3
< f1 | aaa  +
> f1 | aaa    +
7c7
< f1 | bbb\r+
> f1 | bbb\r  +
```

This blocks every PR, not just one.

## Cause

PostgreSQL 18.6 changed psql's expanded output on purpose:

> Make line widths match in psql's expanded aligned output format (Pavel Stehule)
> When the table's data rows are narrower than the record header lines, widen
> the data rows to match the headers, avoiding unsightly output.

Commit [`07a6c262b`](https://postgr.es/c/07a6c262b). The `-[ RECORD 1 ]`
separator is 13 characters wide, so a narrower data row is now padded to 13 and
the `+` continuation marker moves right.

Our test image installs the newest `postgresql-client-18` from pgdg at build
time. That client moved from 18.4 to 18.6, so the stored expected files stopped
matching. 18.5 was never released, which is why the jump skips a version.

Only multi-line values in `\x` output are affected, and only when the row is
narrower than the record separator. Single-line values are untouched.

Verified with the client version as the only variable: same `debian:12-slim`
base, same pgdg repo, same `LC_ALL=C`, same 18.4 server.

| psql client | output |
|---|---|
| `18.4-1.pgdg12+1` | `f1 \| aaa  +` |
| `18.6-1.pgdg12+2` | `f1 \| aaa    +` |

## Fix

Diff with `-w` in the sql loop. These tests assert content, not column
alignment, and the script loop directly below already uses `-B -w`.

`-b` is not enough: 18.4 emits `bbb\r+` with no whitespace at all before the
marker, and `-b` only equates differing amounts of whitespace.

Re-pinning the expected files to 18.6 output was the alternative. It would
break again at the next alignment change, and break for anyone whose local
client is still 18.4.

## Tests

`tests/unit` passes on PG16, PG17 and PG18.
