### PR TITLE
Check publication privileges before creating one

### DIFF
--- a/.github/workflows/run-tests-tiered.yml
+++ b/.github/workflows/run-tests-tiered.yml
@@ -151,6 +151,7 @@ jobs:
           - cdc-wal2json
           - cdc-pgoutput
           - cdc-filtering-pgoutput
+          - pgoutput-privileges
           - follow-wal2json
           - follow-pgoutput
           - follow-standby

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5334,25 +5334,23 @@ appendStringLiteralPub(PQExpBuffer buf, const char *str)
 }
 
 
-bool
-pgsql_create_publication(PGSQL *pgsql, const char *pubName,
-						 struct SourceFilters *filters)
+/*
+ * publication_append_table_query appends the query that lists the tables to
+ * publish. The caller provides the SELECT clause so that the table list and
+ * the pre-flight privilege check always see the same set of tables.
+ */
+static void
+publication_append_table_query(PQExpBuffer query,
+							   const char *selectClause,
+							   struct SourceFilters *filters)
 {
-	PQExpBuffer query = createPQExpBuffer();
-
-	if (query == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-
 	/*
 	 * Only ordinary and partitioned tables can be published. Reading
 	 * pg_class/pg_namespace directly avoids the pg_tables view, which does not
 	 * report the relkind we need to filter on.
 	 */
+	appendPQExpBufferStr(query, selectClause);
 	appendPQExpBufferStr(query,
-						 "SELECT n.nspname, c.relname"
 						 "  FROM pg_class c"
 						 "  JOIN pg_namespace n ON n.oid = c.relnamespace"
 						 " WHERE c.relkind IN ('r', 'p')"
@@ -5439,6 +5437,24 @@ pgsql_create_publication(PGSQL *pgsql, const char *pubName,
 			}
 		}
 	}
+}
+
+
+bool
+pgsql_create_publication(PGSQL *pgsql, const char *pubName,
+						 struct SourceFilters *filters)
+{
+	PQExpBuffer query = createPQExpBuffer();
+
+	if (query == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	publication_append_table_query(query,
+								   "SELECT n.nspname, c.relname",
+								   filters);
 
 	appendPQExpBufferStr(query, " ORDER BY n.nspname, c.relname");
 
@@ -5475,13 +5491,25 @@ pgsql_create_publication(PGSQL *pgsql, const char *pubName,
 		return false;
 	}
 
+	/*
+	 * A publication with no table decodes no change at all. Fail here instead
+	 * of streaming an empty change set for the whole migration.
+	 */
+	if (!ctx.hasTable)
+	{
+		log_error("Failed to create publication \"%s\": the source database "
+				  "has no table to publish", pubName);
+		log_info("The pgoutput plugin only decodes the tables of a "
+				 "publication, so a publication with no table would stream "
+				 "no change; review the filters in use");
+		destroyPQExpBuffer(tableList);
+		destroyPQExpBuffer(sql);
+		return false;
+	}
+
 	appendPQExpBufferStr(sql, "CREATE PUBLICATION ");
 	appendQuotedIdentPub(sql, pubName);
-
-	if (ctx.hasTable)
-	{
-		appendPQExpBuffer(sql, " FOR TABLE %s", tableList->data);
-	}
+	appendPQExpBuffer(sql, " FOR TABLE %s", tableList->data);
 
 	destroyPQExpBuffer(tableList);
 
@@ -5546,6 +5574,179 @@ pgsql_publication_exists(PGSQL *pgsql, const char *pubName, bool *exists)
 	}
 
 	*exists = context.parsedOk && context.boolVal;
+
+	return true;
+}
+
+
+/*
+ * pgsql_check_publication_privileges collects everything that decides if
+ * CREATE PUBLICATION can succeed on the source database.
+ *
+ * CREATE PUBLICATION needs the CREATE privilege on the database, and
+ * CREATE PUBLICATION ... FOR TABLE needs ownership of every published table.
+ * Ownership through role membership counts, so the ownership test uses
+ * pg_has_role() the same way the server does.
+ */
+typedef struct PublicationPrivilegesContext
+{
+	PublicationPrivileges *privs;
+	bool parsedOk;
+} PublicationPrivilegesContext;
+
+
+static void
+parsePublicationRolePrivileges(void *ctx, PGresult *result)
+{
+	PublicationPrivilegesContext *context = (PublicationPrivilegesContext *) ctx;
+
+	if (PQntuples(result) != 1)
+	{
+		log_error("Query returned %d rows, expected 1", PQntuples(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	if (PQnfields(result) != 4)
+	{
+		log_error("Query returned %d columns, expected 4", PQnfields(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	PublicationPrivileges *privs = context->privs;
+
+	strlcpy(privs->rolename, PQgetvalue(result, 0, 0), sizeof(privs->rolename));
+	strlcpy(privs->dbname, PQgetvalue(result, 0, 1), sizeof(privs->dbname));
+
+	privs->canCreateInDatabase = (*(PQgetvalue(result, 0, 2))) == 't';
+	privs->isSuperuser = (*(PQgetvalue(result, 0, 3))) == 't';
+
+	context->parsedOk = true;
+}
+
+
+static void
+parsePublicationTablePrivileges(void *ctx, PGresult *result)
+{
+	PublicationPrivilegesContext *context = (PublicationPrivilegesContext *) ctx;
+
+	if (PQntuples(result) != 1)
+	{
+		log_error("Query returned %d rows, expected 1", PQntuples(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	if (PQnfields(result) != 3)
+	{
+		log_error("Query returned %d columns, expected 3", PQnfields(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	PublicationPrivileges *privs = context->privs;
+	int errors = 0;
+
+	/* 1. count of tables to publish */
+	if (!stringToInt64(PQgetvalue(result, 0, 0), &(privs->tableCount)))
+	{
+		log_error("Invalid table count \"%s\"", PQgetvalue(result, 0, 0));
+		++errors;
+	}
+
+	/* 2. count of those tables the current role does not own */
+	if (!stringToInt64(PQgetvalue(result, 0, 1), &(privs->notOwnedCount)))
+	{
+		log_error("Invalid table count \"%s\"", PQgetvalue(result, 0, 1));
+		++errors;
+	}
+
+	/* 3. one example of a table the current role does not own, may be NULL */
+	if (!PQgetisnull(result, 0, 2))
+	{
+		strlcpy(privs->notOwnedExample,
+				PQgetvalue(result, 0, 2),
+				sizeof(privs->notOwnedExample));
+	}
+
+	if (errors > 0)
+	{
+		context->parsedOk = false;
+		return;
+	}
+
+	context->parsedOk = true;
+}
+
+
+bool
+pgsql_check_publication_privileges(PGSQL *pgsql,
+								   struct SourceFilters *filters,
+								   PublicationPrivileges *privs)
+{
+	PublicationPrivilegesContext context = { privs, false };
+
+	char *rolePrivilegesQuery =
+		"SELECT current_user::text, "
+		"       current_database()::text, "
+		"       has_database_privilege(current_database(), 'CREATE'), "
+		"       coalesce("
+		"         (SELECT rolsuper FROM pg_roles WHERE rolname = current_user), "
+		"         false)";
+
+	if (!pgsql_execute_with_params(pgsql, rolePrivilegesQuery,
+								   0, NULL, NULL,
+								   &context, &parsePublicationRolePrivileges))
+	{
+		return false;
+	}
+
+	if (!context.parsedOk)
+	{
+		log_error("Failed to check the publication privileges of the "
+				  "source database, see above for details");
+		return false;
+	}
+
+	PQExpBuffer query = createPQExpBuffer();
+
+	if (query == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	publication_append_table_query(
+		query,
+		"SELECT count(*), "
+		"       count(*) FILTER (WHERE NOT pg_has_role(current_user, "
+		"                                              c.relowner, 'USAGE')), "
+		"       min(format('%I.%I owned by %I', "
+		"                  n.nspname, c.relname, "
+		"                  pg_get_userbyid(c.relowner))) "
+		"         FILTER (WHERE NOT pg_has_role(current_user, "
+		"                                       c.relowner, 'USAGE')) ",
+		filters);
+
+	context.parsedOk = false;
+
+	if (!pgsql_execute_with_params(pgsql, query->data,
+								   0, NULL, NULL,
+								   &context, &parsePublicationTablePrivileges))
+	{
+		destroyPQExpBuffer(query);
+		return false;
+	}
+
+	destroyPQExpBuffer(query);
+
+	if (!context.parsedOk)
+	{
+		log_error("Failed to check the table ownership of the source "
+				  "database, see above for details");
+		return false;
+	}
 
 	return true;
 }

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -527,10 +527,25 @@ bool pgsql_create_logical_replication_slot(LogicalStreamClient *client,
 /* filtering.h includes this header, so only forward-declare the filter set */
 struct SourceFilters;
 
+/* what decides if CREATE PUBLICATION can succeed on the source */
+typedef struct PublicationPrivileges
+{
+	char rolename[NAMEDATALEN];
+	char dbname[NAMEDATALEN];
+	bool isSuperuser;
+	bool canCreateInDatabase;
+	int64_t tableCount;
+	int64_t notOwnedCount;
+	char notOwnedExample[BUFSIZE];
+} PublicationPrivileges;
+
 bool pgsql_create_publication(PGSQL *pgsql, const char *pubName,
 							  struct SourceFilters *filters);
 bool pgsql_drop_publication(PGSQL *pgsql, const char *pubName);
 bool pgsql_publication_exists(PGSQL *pgsql, const char *pubName, bool *exists);
+bool pgsql_check_publication_privileges(PGSQL *pgsql,
+										struct SourceFilters *filters,
+										PublicationPrivileges *privs);
 
 bool pgsql_timestamptz_to_string(TimestampTz ts, char *str, size_t size);
 

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -639,6 +639,95 @@ copydb_create_logical_replication_slot(CopyDataSpec *copySpecs,
 
 
 /*
+ * snapshot_check_publication_privileges checks that the source database allows
+ * pgcopydb to create its publication, and explains how to proceed when it does
+ * not.
+ *
+ * CREATE PUBLICATION needs the CREATE privilege on the database, and
+ * CREATE PUBLICATION ... FOR TABLE needs ownership of every published table.
+ * Many managed Postgres services never grant either one to a migration role,
+ * so this is a common setup, not an edge case.
+ */
+static bool
+snapshot_check_publication_privileges(PGSQL *src,
+									  CopyDataSpec *copySpecs,
+									  ReplicationSlot *slot)
+{
+	PublicationPrivileges privs = { 0 };
+
+	if (!pgsql_check_publication_privileges(src,
+											&(copySpecs->filters),
+											&privs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	bool missingCreate = !privs.canCreateInDatabase;
+	bool missingOwnership = privs.notOwnedCount > 0;
+
+	if (!missingCreate && !missingOwnership)
+	{
+		return true;
+	}
+
+	log_error("Failed to create publication \"%s\": role \"%s\" is not "
+			  "allowed to create a publication on database \"%s\"",
+			  slot->publicationName,
+			  privs.rolename,
+			  privs.dbname);
+
+	if (missingCreate)
+	{
+		log_error("Role \"%s\" has no CREATE privilege on database \"%s\"",
+				  privs.rolename, privs.dbname);
+	}
+
+	if (missingOwnership)
+	{
+		log_error("Role \"%s\" does not own %lld of the %lld tables to "
+				  "publish, such as %s",
+				  privs.rolename,
+				  (long long) privs.notOwnedCount,
+				  (long long) privs.tableCount,
+				  privs.notOwnedExample);
+	}
+
+	log_info("Use one of the following options to continue:");
+
+	if (missingCreate)
+	{
+		log_info("1. grant the missing privilege, as the owner of "
+				 "database \"%s\" or as a superuser:",
+				 privs.dbname);
+		log_info("     GRANT CREATE ON DATABASE \"%s\" TO \"%s\";",
+				 privs.dbname, privs.rolename);
+	}
+
+	if (missingOwnership)
+	{
+		log_info("1. grant role \"%s\" membership in the role that owns the "
+				 "tables, as a superuser:", privs.rolename);
+		log_info("     GRANT \"<table owner>\" TO \"%s\";", privs.rolename);
+	}
+
+	log_info("2. create the publication once with a privileged role, then "
+			 "pass --publication to use it:");
+	log_info("     CREATE PUBLICATION \"%s\" FOR ALL TABLES;  "
+			 "-- needs a superuser",
+			 slot->publicationName);
+	log_info("     pgcopydb ... --publication \"%s\"", slot->publicationName);
+	log_info("   pgcopydb never drops a publication named with --publication, "
+			 "and a publication wider than the copied tables is safe");
+
+	log_info("3. use an output plugin that needs no publication:");
+	log_info("     pgcopydb ... --plugin wal2json");
+
+	return false;
+}
+
+
+/*
  * snapshot_prepare_publication makes sure that a publication exists for the
  * pgoutput plugin.
  *
@@ -734,6 +823,18 @@ snapshot_prepare_publication(CopyDataSpec *copySpecs, ReplicationSlot *slot)
 				 slot->publicationName);
 		pgsql_finish(&src);
 		return true;
+	}
+
+	/*
+	 * Check the privileges before the DDL, so that a source database that
+	 * does not allow CREATE PUBLICATION fails with the instructions to fix
+	 * it, instead of with a bare "permission denied" from the server.
+	 */
+	if (!snapshot_check_publication_privileges(&src, copySpecs, slot))
+	{
+		/* errors have already been logged */
+		pgsql_finish(&src);
+		return false;
 	}
 
 	if (!pgsql_create_publication(&src, slot->publicationName,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
 all: pagila pagila-multi-steps blobs unit filtering filtering-standby extensions \
 	 cdc-wal2json cdc-test-decoding cdc-endpos-between-transaction cdc-low-level \
-	 cdc-pgoutput cdc-filtering-pgoutput \
+	 cdc-pgoutput cdc-filtering-pgoutput pgoutput-privileges \
 	 cdc-filtering \
 	 cdc-prune \
 	 follow-pgoutput follow-wal2json follow-standby follow-9.6 follow-data-only follow-target-reconnect \
@@ -66,6 +66,9 @@ cdc-pgoutput: build
 	$(MAKE) -C $@
 
 cdc-filtering-pgoutput: build
+	$(MAKE) -C $@
+
+pgoutput-privileges: build
 	$(MAKE) -C $@
 
 follow-pgoutput: build

--- a/tests/pgoutput-privileges/Dockerfile
+++ b/tests/pgoutput-privileges/Dockerfile
@@ -1,0 +1,8 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/pgoutput-privileges/Makefile
+++ b/tests/pgoutput-privileges/Makefile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	$(DOCKER) compose up $(COMPOSE_EXIT)
+
+run: build
+	$(DOCKER) compose run test
+
+down:
+	$(DOCKER) compose down
+
+build:
+	$(DOCKER) compose build
+
+.PHONY: run down build test

--- a/tests/pgoutput-privileges/compose.yaml
+++ b/tests/pgoutput-privileges/compose.yaml
@@ -1,0 +1,40 @@
+services:
+  source:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGSSLMODE: "require"
+      # pgcopydb runs as the unprivileged migration role
+      PGCOPYDB_SOURCE_PGURI: postgres://migration_user:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_OUTPUT_PLUGIN: pgoutput
+      ADMIN_PGURI: postgres://postgres:h4ckm3@source/postgres
+    depends_on:
+      - source
+      - target

--- a/tests/pgoutput-privileges/copydb.sh
+++ b/tests/pgoutput-privileges/copydb.sh
@@ -1,0 +1,141 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Disable pager for psql to avoid hanging in non-interactive environments
+export PAGER=cat
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI    the unprivileged migration role
+#  - PGCOPYDB_TARGET_PGURI
+#  - ADMIN_PGURI              a superuser on the source database
+
+# the migration role does not exist yet, so wait on the admin connection
+for i in $(seq 1 30)
+do
+    psql -At -d "${ADMIN_PGURI}" -c 'select 1' && break
+    sleep 1
+done
+
+psql -d "${ADMIN_PGURI}" -f /usr/src/pgcopydb/ddl.sql
+
+#
+# Phase 1: the migration role has neither CREATE on the database nor the
+# ownership of the tables. pgcopydb must fail before it creates anything.
+#
+if pgcopydb snapshot --follow --plugin pgoutput > /tmp/phase1.log 2>&1
+then
+    echo "pgcopydb must fail when it cannot create the publication"
+    cat /tmp/phase1.log
+    exit 1
+fi
+
+cat /tmp/phase1.log
+
+# both causes are reported, so that one run reports the whole problem
+grep 'has no CREATE privilege on database' /tmp/phase1.log
+grep 'does not own 3 of the 3 tables to publish' /tmp/phase1.log
+grep 'owned by app_owner' /tmp/phase1.log
+
+# the three ways out are all offered
+grep 'GRANT CREATE ON DATABASE' /tmp/phase1.log
+grep -- '--publication' /tmp/phase1.log
+grep -- '--plugin wal2json' /tmp/phase1.log
+
+# a failed pre-flight leaves no publication and no replication slot behind
+pubcount=`psql -At -d "${ADMIN_PGURI}" -c 'select count(*) from pg_publication'`
+slotcount=`psql -At -d "${ADMIN_PGURI}" \
+                -c 'select count(*) from pg_replication_slots'`
+
+if [ "${pubcount}" != "0" -o "${slotcount}" != "0" ]
+then
+    echo "the failed run left ${pubcount} publication(s) and ${slotcount} slot(s)"
+    exit 1
+fi
+
+#
+# Phase 2: grant CREATE on the database. Ownership is still missing, so
+# pgcopydb must still fail, and must now report only the ownership problem.
+#
+psql -d "${ADMIN_PGURI}" -c 'GRANT CREATE ON DATABASE postgres TO migration_user'
+
+if pgcopydb snapshot --follow --plugin pgoutput > /tmp/phase2.log 2>&1
+then
+    echo "pgcopydb must fail when it does not own the tables to publish"
+    cat /tmp/phase2.log
+    exit 1
+fi
+
+cat /tmp/phase2.log
+
+grep 'does not own 3 of the 3 tables to publish' /tmp/phase2.log
+! grep 'has no CREATE privilege on database' /tmp/phase2.log
+
+#
+# Phase 3: grant membership in the role that owns the tables. Ownership
+# through role membership counts, so pgcopydb must now succeed.
+#
+psql -d "${ADMIN_PGURI}" -c 'GRANT app_owner TO migration_user'
+
+coproc ( pgcopydb snapshot --follow --plugin pgoutput )
+
+sleep 2
+
+pubcount=`psql -At -d "${ADMIN_PGURI}" \
+               -c "select count(*) from pg_publication where pubname = 'pgcopydb'"`
+
+if [ "${pubcount}" != "1" ]
+then
+    echo "expected pgcopydb to create the publication \"pgcopydb\""
+    psql -d "${ADMIN_PGURI}" -c 'select * from pg_publication'
+    exit 1
+fi
+
+# the publication covers the three tables of the migration
+tablecount=`psql -At -d "${ADMIN_PGURI}" \
+                 -c "select count(*) from pg_publication_tables
+                      where pubname = 'pgcopydb'"`
+
+if [ "${tablecount}" != "3" ]
+then
+    echo "expected 3 tables in the publication, found ${tablecount}"
+    psql -d "${ADMIN_PGURI}" -c 'select * from pg_publication_tables'
+    exit 1
+fi
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
+
+#
+# Phase 4: an explicit --publication is used as-is, with no CREATE at all.
+#
+psql -d "${ADMIN_PGURI}" -c 'REVOKE CREATE ON DATABASE postgres FROM migration_user'
+psql -d "${ADMIN_PGURI}" -c 'REVOKE app_owner FROM migration_user'
+psql -d "${ADMIN_PGURI}" -c 'DROP PUBLICATION pgcopydb'
+psql -d "${ADMIN_PGURI}" -c 'CREATE PUBLICATION customer_pub FOR ALL TABLES'
+psql -d "${ADMIN_PGURI}" \
+     -c "select pg_drop_replication_slot('pgcopydb')
+          from pg_replication_slots where slot_name = 'pgcopydb'"
+
+# a new work directory, the previous phase recorded another publication name
+coproc ( pgcopydb snapshot --follow --plugin pgoutput \
+                  --publication customer_pub --dir /tmp/phase4 )
+
+sleep 2
+
+# pgcopydb used the given publication and created none of its own
+pubcount=`psql -At -d "${ADMIN_PGURI}" \
+               -c "select count(*) from pg_publication where pubname = 'pgcopydb'"`
+
+if [ "${pubcount}" != "0" ]
+then
+    echo "pgcopydb must not create a publication when --publication is used"
+    exit 1
+fi
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
+
+echo "pgoutput-privileges: all phases passed"

--- a/tests/pgoutput-privileges/ddl.sql
+++ b/tests/pgoutput-privileges/ddl.sql
@@ -1,0 +1,16 @@
+-- A migration role that owns no table, in the shape that managed Postgres
+-- services hand out: it can read and it can stream, but it cannot create a
+-- publication.
+CREATE ROLE app_owner NOLOGIN;
+CREATE ROLE migration_user LOGIN PASSWORD 'h4ckm3' REPLICATION;
+
+CREATE TABLE payment(id bigint primary key, amount numeric);
+CREATE TABLE invoice(id bigint primary key, payment_id bigint, label text);
+CREATE TABLE ledger(id bigint primary key, entry text);
+
+ALTER TABLE payment OWNER TO app_owner;
+ALTER TABLE invoice OWNER TO app_owner;
+ALTER TABLE ledger OWNER TO app_owner;
+
+GRANT USAGE ON SCHEMA public TO migration_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO migration_user;


### PR DESCRIPTION
## Problem

With `--plugin pgoutput` (the default since #58), pgcopydb creates its own publication. `CREATE PUBLICATION` needs `CREATE` on the database, and `CREATE PUBLICATION ... FOR TABLE` needs ownership of every published table. Managed Postgres services often grant neither to a migration role.

The run failed mid-flight with a bare server error and no guidance:

```
ERROR [SOURCE 96659] ERROR:  permission denied for database railway
ERROR snapshot.c:742  Failed to create publication "pgcopydb"
```

## Change

Check both privileges before the DDL and report every way forward in one pass:

```
ERROR Role "migration_user" has no CREATE privilege on database "railway"
ERROR Role "migration_user" does not own 180 of the 180 tables to publish,
      such as public.invoice owned by app_owner
INFO  1. GRANT CREATE ON DATABASE "railway" TO "migration_user";
INFO  2. CREATE PUBLICATION "pgcopydb" FOR ALL TABLES;  -- needs a superuser
INFO     pgcopydb ... --publication "pgcopydb"
INFO  3. pgcopydb ... --plugin wal2json
```

Both causes are reported together, so fixing one does not reveal the other on the next run.

- Ownership uses `pg_has_role(current_user, c.relowner, 'USAGE')`, matching the server's own check, so membership in the owning role counts and superusers pass.
- The table-list query is extracted into `publication_append_table_query()`, shared by the check and the `CREATE`. The check counts exactly the tables the publication would list, filters included.
- Also fixes a silent failure: an empty table list produced `CREATE PUBLICATION "pgcopydb"` with no `FOR TABLE`, which decodes no change at all. It now fails with an explanation.

No CLI or docs change.

## Test

New `tests/pgoutput-privileges` suite, four phases:

1. No `CREATE`, no ownership: fails, reports both causes and all three options, leaves no publication or slot behind.
2. `CREATE` granted, ownership missing: fails, reports only ownership.
3. Membership in the owning role granted: succeeds, publication covers the 3 tables.
4. `--publication` given: used as-is, pgcopydb creates none of its own.

Added to `tests/Makefile` and the CI integration matrix.

## Results

Full PG18 suite run locally. All suites pass except `exclude-extension`, which is a pre-existing failure unrelated to this change: `tests/exclude-extension/Dockerfile:1` defaults `PGCOPYDB_IMAGE` to `pgcopydb:pg16` and its compose file passes no build arg, so it only works on PG16. It is not in the CI matrix.

Style check passes (`citus_indent --check`).